### PR TITLE
Make nodes shutdown in parallel.

### DIFF
--- a/daemon/core/session.py
+++ b/daemon/core/session.py
@@ -692,9 +692,14 @@ class Session(object):
         '''
         self.evq.stop()
         with self._objslock:
+            threads = []
             for obj in self.objs():
                 if isinstance(obj, nodes.PyCoreNode):
-                    self.services.stopnodeservices(obj)
+                    thread = threading.Thread(target=self.services.stopnodeservices, args=(obj,))
+                    thread.start()
+                    threads.append(thread)
+            for thread in threads:
+                thread.join()
         self.emane.shutdown()
         self.updatectrlifhosts(remove=True)
         # Remove all four possible control networks. Does nothing if ctrlnet is not installed.


### PR DESCRIPTION
At the moment nodes' services are shutdown in a serial fashion when going in to datacollect. Most of the services that come with CORE just kill the process so this is not really a bottle neck. Those that do initiate a service shutdown that may still be running will be killed when the node is terminated. This means the shutdown is not clean but as the node and files are deleted anyway it generally does not matter.

With my docker service however I have discovered that if the node tries to terminate when the docker service is still being shutdown it causes a hanging process which is consuming CPU and cannot be killed. I have had to solve this by busy waiting to ensure the docker shutdown completes. The problem is it can take over 10 seconds and as the nodes are shutdown in a serial fashion then this can scale up to be a long wait for shutdown.

I have patched my branch to call all the nodes for shutdown in their own thread and then to wait for all of them to finish before proceeding. As an example 25 docker nodes were taking ~290 seconds to shutdown but with the parallel approach they take just 15 seconds.

For the reasons given above it makes no speed difference to most services but does not seem to harm either. 
