### PR TITLE
deprecate quagga 'vtysh' service

### DIFF
--- a/daemon/core/misc/xmlparser1.py
+++ b/daemon/core/misc/xmlparser1.py
@@ -911,12 +911,12 @@ class CoreDocumentParser1(object):
     def parse_default_services(self):
         # defaults from the CORE GUI
         self.default_services = {
-            'router': ['zebra', 'OSPFv2', 'OSPFv3', 'vtysh', 'IPForward'],
+            'router': ['zebra', 'OSPFv2', 'OSPFv3', 'IPForward'],
             'host': ['DefaultRoute', 'SSH'],
             'PC': ['DefaultRoute',],
-            'mdr': ['zebra', 'OSPFv3MDR', 'vtysh', 'IPForward'],
-            # 'prouter': ['zebra', 'OSPFv2', 'OSPFv3', 'vtysh', 'IPForward'],
-            # 'xen': ['zebra', 'OSPFv2', 'OSPFv3', 'vtysh', 'IPForward'],
+            'mdr': ['zebra', 'OSPFv3MDR', 'IPForward'],
+            # 'prouter': ['zebra', 'OSPFv2', 'OSPFv3', 'IPForward'],
+            # 'xen': ['zebra', 'OSPFv2', 'OSPFv3', 'IPForward'],
             }
         default_services = \
             getFirstChildByTagName(self.scenario, 'CORE:defaultservices')

--- a/daemon/core/services/quagga.py
+++ b/daemon/core/services/quagga.py
@@ -30,7 +30,6 @@ class Zebra(CoreService):
     '''
     _name = "zebra"
     _group = "Quagga"
-    _depends = ("vtysh", )
     _dirs = ("/usr/local/etc/quagga",  "/var/run/quagga")
     _configs = ("/usr/local/etc/quagga/Quagga.conf",
                 "quaggaboot.sh","/usr/local/etc/quagga/vtysh.conf")
@@ -205,17 +204,10 @@ bootdaemon()
     $FLOCK_BIN_DIR/flock $QUAGGA_STATE_DIR $QUAGGA_BIN_DIR/vtysh -b
 }
 
-bootvtysh()
-{
-    echo "'vtysh' service is deprecated!"
-}
-
 confcheck
 if [ "x$1" = "x" ]; then
     echo "ERROR: missing the name of the Quagga daemon to boot"
     exit 1
-elif [ "$1" = "vtysh" ]; then
-    bootvtysh $1
 else
     bootdaemon $1
 fi
@@ -590,21 +582,3 @@ class Xpimd(QuaggaService):
         return '  ip mfea\n  ip igmp\n  ip pim\n'
 
 addservice(Xpimd)
-
-class Vtysh(CoreService):
-    ''' Simple service to run vtysh -b (boot) after all Quagga daemons have
-        started.
-    '''
-    _name = "vtysh"
-    _group = "Quagga"
-    _startindex = 45
-    _startup = ("sh quaggaboot.sh vtysh",)
-    _shutdown = ()
-
-    @classmethod
-    def generateconfig(cls, node, filename, services):
-        return ""
-
-addservice(Vtysh)
-
-

--- a/daemon/core/xen/xen.py
+++ b/daemon/core/xen/xen.py
@@ -109,7 +109,6 @@ class XenNode(PyCoreNode):
         #'sh quaggaboot.sh zebra',
         #'sh quaggaboot.sh ospfd',
         #'sh quaggaboot.sh ospf6d',
-        'sh quaggaboot.sh vtysh',
         'killall zebra',
         'killall ospfd',
         'killall ospf6d',

--- a/daemon/examples/netns/emane80211.py
+++ b/daemon/examples/netns/emane80211.py
@@ -70,7 +70,7 @@ def main():
         values[ names.index('propagationmodel') ] = '2ray'
         
     session.emane.setconfig(wlan.objid, EmaneIeee80211abgModel._name, values)
-    services_str = "zebra|OSPFv3MDR|vtysh|IPForward"
+    services_str = "zebra|OSPFv3MDR|IPForward"
 
     print "creating %d nodes with addresses from %s" % \
           (options.numnodes, prefix)

--- a/daemon/examples/netns/howmanynodes.py
+++ b/daemon/examples/netns/howmanynodes.py
@@ -97,7 +97,7 @@ def main():
     parser.add_option("-s", "--services", dest = "services", type = str,
                       help = "pipe-delimited list of services added to each " \
                       "node (default = %s)\n(Example: 'zebra|OSPFv2|OSPFv3|" \
-                      "vtysh|IPForward')" % parser.defaults["services"])
+                      "IPForward')" % parser.defaults["services"])
 
     def usage(msg = None, err = 0):
         sys.stdout.write("\n")

--- a/daemon/ns3/examples/ns3wifirandomwalk.py
+++ b/daemon/ns3/examples/ns3wifirandomwalk.py
@@ -66,7 +66,7 @@ def wifisession(opt):
     wifi.phy.Set("RxGain", ns.core.DoubleValue(18.0))
 
     prefix = ipaddr.IPv4Prefix("10.0.0.0/16")
-    services_str = "zebra|OSPFv3MDR|vtysh|IPForward"
+    services_str = "zebra|OSPFv3MDR|IPForward"
     nodes = []
     for i in xrange(1, opt.numnodes + 1):
         node = session.addnode(name = "n%d" % i)

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -1448,13 +1448,13 @@ Here are the default node types and their services:
 .. index:: Xen
 .. index:: physical nodes
 
-* *router* - zebra, OSFPv2, OSPFv3, vtysh, and IPForward services for IGP
+* *router* - zebra, OSFPv2, OSPFv3, and IPForward services for IGP
   link-state routing.
 * *host* - DefaultRoute and SSH services, representing an SSH server having a
   default route when connected directly to a router.
 * *PC* - DefaultRoute service for having a default route when connected
   directly to a router.
-* *mdr* - zebra, OSPFv3MDR, vtysh, and IPForward services for
+* *mdr* - zebra, OSPFv3MDR, and IPForward services for
   wireless-optimized MANET Designated Router routing.
 * *prouter* - a physical router, having the same default services as the
   *router* node type; for incorporating Linux testbed machines into an

--- a/gui/configs/sample1.imn
+++ b/gui/configs/sample1.imn
@@ -105,7 +105,7 @@ node n5 {
     labelcoords {540.0 376.0}
     interface-peer {eth0 n10}
     interface-peer {eth1 n15}
-    services {zebra OSPFv2 OSPFv3MDR vtysh IPForward}
+    services {zebra OSPFv2 OSPFv3MDR IPForward}
     custom-config {
 	custom-config-id service:zebra
 	custom-command zebra

--- a/gui/configs/sample10-kitchen-sink.imn
+++ b/gui/configs/sample10-kitchen-sink.imn
@@ -283,7 +283,7 @@ node n11 {
 	
 	}
     }
-    services {zebra OSPFv2 OSPFv3MDR vtysh IPForward}
+    services {zebra OSPFv2 OSPFv3MDR IPForward}
 }
 
 node n12 {
@@ -517,7 +517,7 @@ node n20 {
 	
 	}
     }
-    services {zebra OSPFv2 OSPFv3MDR vtysh IPForward}
+    services {zebra OSPFv2 OSPFv3MDR IPForward}
 }
 
 node n21 {

--- a/gui/configs/sample3-bgp.imn
+++ b/gui/configs/sample3-bgp.imn
@@ -20,7 +20,7 @@ node n1 {
     interface-peer {eth1 n2}
     interface-peer {eth2 n3}
     canvas c1
-    services {zebra BGP vtysh IPForward}
+    services {zebra BGP IPForward}
     custom-config {
 	custom-config-id service:zebra:/usr/local/etc/quagga/Quagga.conf
 	custom-command /usr/local/etc/quagga/Quagga.conf
@@ -82,7 +82,7 @@ node n2 {
     interface-peer {eth1 n16}
     interface-peer {eth2 n6}
     canvas c1
-    services {zebra BGP vtysh IPForward}
+    services {zebra BGP IPForward}
     custom-config {
 	custom-config-id service:zebra:/usr/local/etc/quagga/Quagga.conf
 	custom-command /usr/local/etc/quagga/Quagga.conf
@@ -140,7 +140,7 @@ node n3 {
     interface-peer {eth0 n4}
     interface-peer {eth1 n1}
     canvas c1
-    services {zebra BGP vtysh IPForward}
+    services {zebra BGP IPForward}
     custom-config {
 	custom-config-id service:zebra:/usr/local/etc/quagga/Quagga.conf
 	custom-command /usr/local/etc/quagga/Quagga.conf
@@ -197,7 +197,7 @@ node n4 {
     interface-peer {eth0 n3}
     interface-peer {eth1 n7}
     canvas c1
-    services {zebra BGP vtysh IPForward}
+    services {zebra BGP IPForward}
     custom-config {
 	custom-config-id service:zebra:/usr/local/etc/quagga/Quagga.conf
 	custom-command /usr/local/etc/quagga/Quagga.conf
@@ -258,7 +258,7 @@ node n5 {
     interface-peer {eth0 n7}
     interface-peer {eth1 n6}
     canvas c1
-    services {zebra BGP vtysh IPForward}
+    services {zebra BGP IPForward}
     custom-config {
 	custom-config-id service:zebra:/usr/local/etc/quagga/Quagga.conf
 	custom-command /usr/local/etc/quagga/Quagga.conf
@@ -323,7 +323,7 @@ node n6 {
     interface-peer {eth0 n5}
     interface-peer {eth1 n2}
     canvas c1
-    services {zebra BGP vtysh IPForward}
+    services {zebra BGP IPForward}
     custom-config {
 	custom-config-id service:zebra:/usr/local/etc/quagga/Quagga.conf
 	custom-command /usr/local/etc/quagga/Quagga.conf
@@ -376,7 +376,7 @@ node n7 {
     interface-peer {eth0 n5}
     interface-peer {eth1 n4}
     canvas c1
-    services {zebra BGP vtysh IPForward}
+    services {zebra BGP IPForward}
     custom-config {
 	custom-config-id service:zebra:/usr/local/etc/quagga/Quagga.conf
 	custom-command /usr/local/etc/quagga/Quagga.conf
@@ -555,7 +555,7 @@ node n16 {
     interface-peer {eth0 n1}
     interface-peer {eth1 n2}
     canvas c1
-    services {zebra BGP vtysh IPForward}
+    services {zebra BGP IPForward}
     custom-config {
 	custom-config-id service:zebra:/usr/local/etc/quagga/Quagga.conf
 	custom-command /usr/local/etc/quagga/Quagga.conf

--- a/gui/configs/sample4-nrlsmf.imn
+++ b/gui/configs/sample4-nrlsmf.imn
@@ -65,7 +65,7 @@ node n1 {
     canvas c1
     interface-peer {eth0 n11}
     custom-image $CORE_DATA_DIR/icons/normal/router_green.gif
-    services {zebra OSPFv3MDR vtysh SMF IPForward UserDefined}
+    services {zebra OSPFv3MDR SMF IPForward UserDefined}
     custom-config {
 	custom-config-id service:UserDefined:custom-post-config-commands.sh
 	custom-command custom-post-config-commands.sh
@@ -101,7 +101,7 @@ node n2 {
     canvas c1
     interface-peer {eth0 n11}
     custom-image $CORE_DATA_DIR/icons/normal/router_green.gif
-    services {zebra OSPFv3MDR vtysh SMF IPForward UserDefined}
+    services {zebra OSPFv3MDR SMF IPForward UserDefined}
     custom-config {
 	custom-config-id service:UserDefined:custom-post-config-commands.sh
 	custom-command custom-post-config-commands.sh
@@ -137,7 +137,7 @@ node n3 {
     canvas c1
     interface-peer {eth0 n11}
     custom-image $CORE_DATA_DIR/icons/normal/router_green.gif
-    services {zebra OSPFv3MDR vtysh SMF IPForward UserDefined}
+    services {zebra OSPFv3MDR SMF IPForward UserDefined}
     custom-config {
 	custom-config-id service:UserDefined:custom-post-config-commands.sh
 	custom-command custom-post-config-commands.sh
@@ -173,7 +173,7 @@ node n4 {
     canvas c1
     interface-peer {eth0 n11}
     custom-image $CORE_DATA_DIR/icons/normal/router_green.gif
-    services {zebra OSPFv3MDR vtysh SMF IPForward UserDefined}
+    services {zebra OSPFv3MDR SMF IPForward UserDefined}
     custom-config {
 	custom-config-id service:UserDefined:custom-post-config-commands.sh
 	custom-command custom-post-config-commands.sh
@@ -209,7 +209,7 @@ node n5 {
     canvas c1
     interface-peer {eth0 n11}
     custom-image $CORE_DATA_DIR/icons/normal/router_green.gif
-    services {zebra OSPFv3MDR vtysh SMF IPForward UserDefined}
+    services {zebra OSPFv3MDR SMF IPForward UserDefined}
     custom-config {
 	custom-config-id service:UserDefined:custom-post-config-commands.sh
 	custom-command custom-post-config-commands.sh
@@ -245,7 +245,7 @@ node n6 {
     canvas c1
     interface-peer {eth0 n11}
     custom-image $CORE_DATA_DIR/icons/normal/router_red.gif
-    services {zebra OSPFv3MDR vtysh SMF IPForward UserDefined}
+    services {zebra OSPFv3MDR SMF IPForward UserDefined}
     custom-config {
 	custom-config-id service:UserDefined:custom-post-config-commands.sh
 	custom-command custom-post-config-commands.sh
@@ -281,7 +281,7 @@ node n7 {
     canvas c1
     interface-peer {eth0 n11}
     custom-image $CORE_DATA_DIR/icons/normal/router_red.gif
-    services {zebra OSPFv3MDR vtysh SMF IPForward UserDefined}
+    services {zebra OSPFv3MDR SMF IPForward UserDefined}
     custom-config {
 	custom-config-id service:UserDefined:custom-post-config-commands.sh
 	custom-command custom-post-config-commands.sh
@@ -317,7 +317,7 @@ node n8 {
     canvas c1
     interface-peer {eth0 n11}
     custom-image $CORE_DATA_DIR/icons/normal/router_red.gif
-    services {zebra OSPFv3MDR vtysh SMF IPForward UserDefined}
+    services {zebra OSPFv3MDR SMF IPForward UserDefined}
     custom-config {
 	custom-config-id service:UserDefined:custom-post-config-commands.sh
 	custom-command custom-post-config-commands.sh
@@ -353,7 +353,7 @@ node n9 {
     canvas c1
     interface-peer {eth0 n11}
     custom-image $CORE_DATA_DIR/icons/normal/router_red.gif
-    services {zebra OSPFv3MDR vtysh SMF IPForward UserDefined}
+    services {zebra OSPFv3MDR SMF IPForward UserDefined}
     custom-config {
 	custom-config-id service:UserDefined:custom-post-config-commands.sh
 	custom-command custom-post-config-commands.sh
@@ -389,7 +389,7 @@ node n10 {
     canvas c1
     interface-peer {eth0 n11}
     custom-image $CORE_DATA_DIR/icons/normal/router_red.gif
-    services {zebra OSPFv3MDR vtysh SMF IPForward UserDefined}
+    services {zebra OSPFv3MDR SMF IPForward UserDefined}
     custom-config {
 	custom-config-id service:UserDefined:custom-post-config-commands.sh
 	custom-command custom-post-config-commands.sh

--- a/gui/configs/sample5-mgen.imn
+++ b/gui/configs/sample5-mgen.imn
@@ -51,7 +51,7 @@ node n1 {
 	cmdup=('sh mgen.sh', )
 	}
     }
-    services {zebra OSPFv2 OSPFv3 vtysh IPForward UserDefined}
+    services {zebra OSPFv2 OSPFv3 IPForward UserDefined}
 }
 
 node n2 {
@@ -101,7 +101,7 @@ node n2 {
 	mgen input send_$HN.mgn output $LOGDIR/mgen_$HN.log > /dev/null 2> /dev/null < /dev/null &
 	}
     }
-    services {zebra OSPFv2 OSPFv3 vtysh IPForward UserDefined}
+    services {zebra OSPFv2 OSPFv3 IPForward UserDefined}
 }
 
 link l1 {

--- a/gui/configs/sample8-ipsec-service.imn
+++ b/gui/configs/sample8-ipsec-service.imn
@@ -354,7 +354,7 @@ node n1 {
 	
 	}
     }
-    services {zebra OSPFv2 OSPFv3 vtysh IPForward IPsec}
+    services {zebra OSPFv2 OSPFv3 IPForward IPsec}
     custom-image $CORE_DATA_DIR/icons/normal/router_red.gif
 }
 
@@ -528,7 +528,7 @@ node n2 {
 	
 	}
     }
-    services {zebra OSPFv2 OSPFv3 vtysh IPForward IPsec}
+    services {zebra OSPFv2 OSPFv3 IPForward IPsec}
     custom-image $CORE_DATA_DIR/icons/normal/router_red.gif
 }
 
@@ -697,7 +697,7 @@ node n3 {
 	
 	}
     }
-    services {zebra OSPFv2 OSPFv3 vtysh IPForward IPsec}
+    services {zebra OSPFv2 OSPFv3 IPForward IPsec}
     custom-image $CORE_DATA_DIR/icons/normal/router_red.gif
 }
 

--- a/gui/nodes.tcl
+++ b/gui/nodes.tcl
@@ -15,18 +15,18 @@ if { $execMode == "interactive" } {
 # these are the default node types when nodes.conf does not exist
 #      index {name normal-icon tiny-icon services type metadata}
 array set g_node_types_default {
-	1 {router router.gif router.gif {zebra OSPFv2 OSPFv3 vtysh IPForward} \
+	1 {router router.gif router.gif {zebra OSPFv2 OSPFv3 IPForward} \
 	    netns {built-in type for routing}}
 	2 {host host.gif host.gif {DefaultRoute SSH} \
 	    netns {built-in type for servers}}
 	3 {PC pc.gif pc.gif {DefaultRoute} \
 	    netns {built-in type for end hosts}}
-	4 {mdr mdr.gif mdr.gif {zebra OSPFv3MDR vtysh IPForward} \
+	4 {mdr mdr.gif mdr.gif {zebra OSPFv3MDR IPForward} \
 	    netns {built-in type for wireless routers}}
 	5 {prouter router_green.gif router_green.gif \
-	    {zebra OSPFv2 OSPFv3 vtysh IPForward} \
+	    {zebra OSPFv2 OSPFv3 IPForward} \
 	    physical {built-in type for physical nodes}}
-	6 {xen xen.gif xen.gif {zebra OSPFv2 OSPFv3 vtysh IPForward} \
+	6 {xen xen.gif xen.gif {zebra OSPFv2 OSPFv3 IPForward} \
 	    xen {built-in type for Xen PVM domU router}}
 }
 

--- a/gui/util.tcl
+++ b/gui/util.tcl
@@ -160,7 +160,7 @@ proc upgradeNetworkConfigToServices { } {
 	set bgp [netconfFetchSection $node "router bgp"]
 	if { $ospfv2 != "" || $ospfv3 != "" || $rip != "" || $ripng != "" } {
 	    set cfg ""
-	    set services "zebra vtysh IPForward"
+	    set services "zebra IPForward"
 	    foreach ifc [ifcList $node] {
 		lappend cfg "interface $ifc"
 		set ifccfg [netconfFetchSection $node "interface $ifc"]

--- a/scripts/core-daemon.service.in
+++ b/scripts/core-daemon.service.in
@@ -6,6 +6,7 @@ After=network.target
 Type=forking
 PIDFile=/var/run/core-daemon.pid
 ExecStart=@PYTHON@ @SBINDIR@/core-daemon -d
+TasksMax=infinity
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The two patches in this pull request address a timing/synchronization/busy-waiting problem with Quagga's "vtysh" configuration service. The service is deprecated/removed, and each Quagga routing service becomes responsible for the configuration of its own respective daemon.

See the thread entitled "busy-wait / timeout error in quaggaboot.sh" from December 2016 on the core-users mailing list, and the individual commit messages for the full details.

Thanks,
--Gabriel