### PR TITLE
systemd: remove limit on fork() branching factor

### DIFF
--- a/scripts/core-daemon.service.in
+++ b/scripts/core-daemon.service.in
@@ -6,6 +6,7 @@ After=network.target
 Type=forking
 PIDFile=/var/run/core-daemon.pid
 ExecStart=@PYTHON@ @SBINDIR@/core-daemon -d
+TasksMax=infinity
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
On distributions using systemd, a default limit on the number of
tasks allowed to be created from a given unit may be set by default
(e.g., on F24, "DefaultTasksAccounting=yes" and "DefaultTasksMax=512"
are set in /etc/systemd/system.conf. A large CORE simulation may well
exceed that limit, at least during startup when many (sub)shell
processes are generated using fork().

To avoid running into this limit, set "TasksMax=infinity" in the
core-daemon.service unit file template.

Signed-off-by: Gabriel Somlo <glsomlo@cert.org>