### PR TITLE
daemon: start Quagga with default user/group names

### DIFF
--- a/daemon/core/services/quagga.py
+++ b/daemon/core/services/quagga.py
@@ -20,11 +20,6 @@ from core.misc.ipaddr import IPv4Prefix, isIPv4Address, isIPv6Address
 from core.api import coreapi
 from core.constants import *
 
-QUAGGA_USER="root"
-QUAGGA_GROUP="root"
-if os.uname()[0] == "FreeBSD":
-    QUAGGA_GROUP="wheel"
-
 class Zebra(CoreService):
     ''' 
     '''
@@ -139,8 +134,6 @@ QUAGGA_CONF=%s
 QUAGGA_SBIN_SEARCH=%s
 QUAGGA_BIN_SEARCH=%s
 QUAGGA_STATE_DIR=%s
-QUAGGA_USER=%s
-QUAGGA_GROUP=%s
 
 searchforprog()
 {
@@ -185,7 +178,7 @@ bootdaemon()
         flags="$flags -6"
     fi
 
-    $QUAGGA_SBIN_DIR/$1 $flags -u $QUAGGA_USER -g $QUAGGA_GROUP -d
+    $QUAGGA_SBIN_DIR/$1 $flags -d
     if [ "$?" != "0" ]; then
         echo "ERROR: Quagga's '$1' daemon failed to start!:"
         return 1
@@ -222,7 +215,7 @@ fi
 confcheck
 bootquagga
 """ % (cls._configs[0], quagga_sbin_search, quagga_bin_search, \
-       QUAGGA_STATE_DIR, QUAGGA_USER, QUAGGA_GROUP)
+       QUAGGA_STATE_DIR)
 
 addservice(Zebra)
 


### PR DESCRIPTION
Allow native distribution packages to run with their default user
and group names by no longer forcing "-u root -g root" on any of
the Quagga daemons' command lines.

This should continue to allow hand-compiled and/or "side-loaded"
Quagga software to run as root, if configured to do so at build
time.

Signed-off-by: Gabriel Somlo <glsomlo@cert.org>