### PR TITLE
fix to add correct broadcast address for ipv4 interfaces 

### DIFF
--- a/daemon/core/netns/vnode.py
+++ b/daemon/core/netns/vnode.py
@@ -225,8 +225,12 @@ class SimpleLxcNode(PyCoreNode):
                     "error setting MAC address %s" % str(addr))
     def addaddr(self, ifindex, addr):
         if self.up:
-            self.cmd([IP_BIN, "addr", "add", str(addr),
-                  "dev", self.ifname(ifindex)])
+            if ":" in str(addr): # check if addr is ipv6
+                self.cmd([IP_BIN, "addr", "add", str(addr),
+                    "dev", self.ifname(ifindex)])
+            else:
+                self.cmd([IP_BIN, "addr", "add", str(addr), "broadcast", "+",
+                    "dev", self.ifname(ifindex)])
         self._netif[ifindex].addaddr(addr)
 
     def deladdr(self, ifindex, addr):


### PR DESCRIPTION
Broadcast address is not set for IPv4 interfaces, this patch adds _"broadcast +"_ as a parameter to the _ip_ command. 