### PR TITLE
globally replace mailing list URLs and dev email

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ If you have questions, comments, or trouble, please use the CORE mailing lists:
 - `core-dev`_ for bugs, compile errors, and other development issues
 
 
-.. _core-users: https://pf.itd.nrl.navy.mil/mailman/listinfo/core-users
-.. _core-dev: https://pf.itd.nrl.navy.mil/mailman/listinfo/core-dev
+.. _core-users: https://publists.nrl.navy.mil/mailman/listinfo/core-users
+.. _core-dev: https://publists.nrl.navy.mil/mailman/listinfo/core-dev
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,7 @@
 #
 # this defines the CORE version number, must be static for AC_INIT
 #
-AC_INIT(core, m4_esyscmd_s([./revision.sh 4.8]), core-dev@pf.itd.nrl.navy.mil)
+AC_INIT(core, m4_esyscmd_s([./revision.sh 4.8]), core-dev@nrl.navy.mil)
 VERSION=$PACKAGE_VERSION
 CORE_VERSION=$PACKAGE_VERSION
 CORE_VERSION_DATE=m4_esyscmd_s([./revision.sh -d])

--- a/daemon/core/bsd/netgraph.py
+++ b/daemon/core/bsd/netgraph.py
@@ -3,7 +3,7 @@
 # Copyright (c)2010-2012 the Boeing Company.
 # See the LICENSE file included in this distribution.
 #
-# authors: core-dev@pf.itd.nrl.navy.mil 
+# authors: core-dev@nrl.navy.mil 
 #
 '''
 netgraph.py: Netgraph helper functions; for now these are wrappers around

--- a/daemon/core/bsd/nodes.py
+++ b/daemon/core/bsd/nodes.py
@@ -3,7 +3,7 @@
 # Copyright (c)2010-2013 the Boeing Company.
 # See the LICENSE file included in this distribution.
 #
-# author: core-dev@pf.itd.nrl.navy.mil
+# author: core-dev@nrl.navy.mil
 #
 
 '''

--- a/daemon/core/bsd/vnet.py
+++ b/daemon/core/bsd/vnet.py
@@ -3,7 +3,7 @@
 # Copyright (c)2010-2012 the Boeing Company.
 # See the LICENSE file included in this distribution.
 #
-# authors: core-dev@pf.itd.nrl.navy.mil
+# authors: core-dev@nrl.navy.mil
 #
 '''
 vnet.py: NetgraphNet and NetgraphPipeNet classes that implement virtual networks

--- a/daemon/core/bsd/vnode.py
+++ b/daemon/core/bsd/vnode.py
@@ -3,7 +3,7 @@
 # Copyright (c)2010-2012 the Boeing Company.
 # See the LICENSE file included in this distribution.
 #
-# authors: core-dev@pf.itd.nrl.navy.mil 
+# authors: core-dev@nrl.navy.mil 
 #
 '''
 vnode.py: SimpleJailNode and JailNode classes that implement the FreeBSD

--- a/daemon/ns3/setup.py
+++ b/daemon/ns3/setup.py
@@ -13,7 +13,7 @@ setup(name = "corens3-python",
       description = "Python ns-3 components of CORE",
       url = "http://www.nrl.navy.mil/itd/ncs/products/core",
       author = "Boeing Research & Technology",
-      author_email = "core-dev@pf.itd.nrl.navy.mil",
+      author_email = "core-dev@nrl.navy.mil",
       license = "GPLv2",
       long_description="Python scripts and modules for building virtual " \
           "simulated networks.")

--- a/daemon/setup.py
+++ b/daemon/setup.py
@@ -22,7 +22,7 @@ setup(name = "core-python",
       description = "Python components of CORE",
       url = "http://www.nrl.navy.mil/itd/ncs/products/core",
       author = "Boeing Research & Technology",
-      author_email = "core-dev@pf.itd.nrl.navy.mil",
+      author_email = "core-dev@nrl.navy.mil",
       license = "BSD",
       long_description="Python scripts and modules for building virtual " \
           "emulated networks.")

--- a/daemon/src/setup.py
+++ b/daemon/src/setup.py
@@ -23,7 +23,7 @@ setup(name = "core-python-netns",
       ext_modules = [netns, vcmd],
       url = "http://www.nrl.navy.mil/itd/ncs/products/core",
       author = "Boeing Research & Technology",
-      author_email = "core-dev@pf.itd.nrl.navy.mil",
+      author_email = "core-dev@nrl.navy.mil",
       license = "BSD",
       long_description="Extension modules and utilities to support virtual " \
           "nodes using Linux network namespaces")

--- a/doc/man/core-cleanup.1
+++ b/doc/man/core-cleanup.1
@@ -25,6 +25,6 @@ remove the core-daemon.log file
 .BR vnoded(1)
 .SH BUGS
 Report bugs to
-.BI core-dev@pf.itd.nrl.navy.mil.
+.BI core-dev@nrl.navy.mil.
 
 

--- a/doc/man/core-daemon.1
+++ b/doc/man/core-daemon.1
@@ -48,5 +48,5 @@ enable debug logging; default = False
 .BR vnoded(1)
 .SH BUGS
 Report bugs to 
-.BI core-dev@pf.itd.nrl.navy.mil.
+.BI core-dev@nrl.navy.mil.
 

--- a/doc/man/core-gui.1
+++ b/doc/man/core-gui.1
@@ -40,5 +40,5 @@ With no parameters, starts the GUI in edit mode with a blank canvas.
 .BR vnoded(1)
 .SH BUGS
 Report bugs to 
-.BI core-dev@pf.itd.nrl.navy.mil.
+.BI core-dev@nrl.navy.mil.
 

--- a/doc/man/core-xen-cleanup.1
+++ b/doc/man/core-xen-cleanup.1
@@ -23,6 +23,6 @@ also kill the Python daemon
 .SH BUGS
 Warning! This script will remove logical volumes that match the name "/dev/vg*/c*-n*-" on all volume groups. Use with care.
 Report bugs to
-.BI core-dev@pf.itd.nrl.navy.mil.
+.BI core-dev@nrl.navy.mil.
 
 

--- a/doc/man/coresendmsg.1
+++ b/doc/man/coresendmsg.1
@@ -82,4 +82,4 @@ coresendmsg \-H
 .BR vnoded(1)
 .SH BUGS
 Report bugs to 
-.BI core-dev@pf.itd.nrl.navy.mil.
+.BI core-dev@nrl.navy.mil.

--- a/doc/man/netns.1
+++ b/doc/man/netns.1
@@ -26,5 +26,5 @@ wait for command to complete (useful for interactive commands)
 .BR vnoded(1)
 .SH BUGS
 Report bugs to 
-.BI core-dev@pf.itd.nrl.navy.mil.
+.BI core-dev@nrl.navy.mil.
 

--- a/doc/man/vcmd.1
+++ b/doc/man/vcmd.1
@@ -38,5 +38,5 @@ control channel name (e.g. '/tmp/pycore.45647/n3')
 .BR vnoded(1),
 .SH BUGS
 Report bugs to 
-.BI core-dev@pf.itd.nrl.navy.mil.
+.BI core-dev@nrl.navy.mil.
 

--- a/doc/man/vnoded.1
+++ b/doc/man/vnoded.1
@@ -40,5 +40,5 @@ establish the specified <control channel> for receiving control commands
 .BR vcmd(1),
 .SH BUGS
 Report bugs to 
-.BI core-dev@pf.itd.nrl.navy.mil.
+.BI core-dev@nrl.navy.mil.
 

--- a/gui/initgui.tcl
+++ b/gui/initgui.tcl
@@ -604,7 +604,7 @@ menu .menubar.help -tearoff 0
 .menubar.help add command -label "CORE website (www)" -command \
   "_launchBrowser http://www.nrl.navy.mil/itd/ncs/products/core"
 .menubar.help add command -label "Mailing list (www)" -command \
-  "_launchBrowser http://pf.itd.nrl.navy.mil/mailman/listinfo/core-users"
+  "_launchBrowser https://publists.nrl.navy.mil/mailman/listinfo/core-users"
 .menubar.help add command -label "About" -command popupAbout
 
 #

--- a/packaging/deb.mk
+++ b/packaging/deb.mk
@@ -20,7 +20,7 @@ build: changelog
 changelog: debian
 	echo "core ($(CORE_VERSION)-1) unstable; urgency=low" > $(COREBUILD)/debian/changelog.generated
 	echo "  * interim package generated from source" >> $(COREBUILD)/debian/changelog.generated
-	echo " -- CORE Developers <core-dev@pf.itd.nrl.navy.mil>  $$(date -R)" >> $(COREBUILD)/debian/changelog.generated
+	echo " -- CORE Developers <core-dev@nrl.navy.mil>  $$(date -R)" >> $(COREBUILD)/debian/changelog.generated
 	cd $(COREBUILD)/debian && \
 	    { test ! -L changelog && mv -f changelog changelog.save; } && \
 	    { test "$$(readlink changelog)" = "changelog.generated" || \

--- a/packaging/deb/control
+++ b/packaging/deb/control
@@ -1,7 +1,7 @@
 Source: core
 Section: net
 Priority: optional
-Maintainer: CORE Developers <core-dev@pf.itd.nrl.navy.mil>
+Maintainer: CORE Developers <core-dev@nrl.navy.mil>
 Standards-Version: 3.8.4
 Build-Depends: debhelper (>= 9), cdbs, dh-autoreconf, autoconf, automake, gcc, libev-dev, make, python-dev, libreadline-dev, bridge-utils, ebtables, iproute2 | iproute, imagemagick, pkg-config, help2man
 # python-sphinx


### PR DESCRIPTION
This PR simply updates the URLs and email addresses for the core-users and core-dev mailing lists.

NFC (no functional change)

----

update to:
https://publists.nrl.navy.mil/mailman/listinfo/core-users
https://publists.nrl.navy.mil/mailman/listinfo/core-dev

dev email:
core-dev@nrl.navy.mil