### PR TITLE
broke commands to separate lines

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,8 +34,11 @@ Building CORE
 To build this software you should use:
 
     ./bootstrap.sh
+
     ./configure
+    
     make
+    
     sudo make install
 
 Here is what is installed with 'make install':


### PR DESCRIPTION
Currently all of the commands show on the same line, which makes them fail with an error.  See on the main project page here on Github under `Build`.  I couldn't find a way to do it without the extra line break for the `.rst` file format.

