### PR TITLE
removed cflag -Werror

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -115,7 +115,7 @@ AC_SUBST(CORE_STATE_DIR)
 
 # default compiler flags
 # _GNU_SOURCE is defined to get c99 defines for lrint()
-CFLAGS="$CFLAGS -O3 -Werror -Wall -D_GNU_SOURCE"
+CFLAGS="$CFLAGS -O3 -Wall -D_GNU_SOURCE"
 # debug flags
 #CFLAGS="$CFLAGS -g -Werror -Wall -D_GNU_SOURCE"
 

--- a/configure.ac
+++ b/configure.ac
@@ -115,7 +115,7 @@ AC_SUBST(CORE_STATE_DIR)
 
 # default compiler flags
 # _GNU_SOURCE is defined to get c99 defines for lrint()
-CFLAGS="$CFLAGS -O3 -Wall -D_GNU_SOURCE"
+CFLAGS="$CFLAGS -O3 -Werror -Wall -Wno-int-in-bool-context -D_GNU_SOURCE"
 # debug flags
 #CFLAGS="$CFLAGS -g -Werror -Wall -D_GNU_SOURCE"
 


### PR DESCRIPTION
This solves #128

gcc7 has a compatibility problem with python and issues a warning as described at https://bugzilla.redhat.com/show_bug.cgi?id=1473425  

Setting the `-Werror` flag treats all warnings as errors, which fails the build.  IMHO it is better to remove the flag from regular builds.  Advanced users can add it if they choose to.