### PR TITLE
SimpleLxcNode: Don't umount directories before killing vnoded

### DIFF
--- a/daemon/core/netns/vnode.py
+++ b/daemon/core/netns/vnode.py
@@ -120,7 +120,8 @@ class SimpleLxcNode(PyCoreNode):
         # unmount all targets
         while self._mounts:
             source, target = self._mounts.pop(-1)
-            self.umount(target)
+            # Mount namespaces automatically removed when last process exits!
+            #self.umount(target)
 
         # shutdown all interfaces
         for netif in self.netifs():


### PR DESCRIPTION
A node's private mounts are currently removed before killing
vnoded, which makes them unavailable during container service
shutdown. Any such service accessing the filesystem for atexit()
cleanup (e.g., rsyslogd), will do so on the host filesystem
instead, very likely causing unintended damage.

For example, the default behavior of rsyslogd is to remove its
listening socket (/dev/log, or /run/systemd/journal/dev-log) at
shutdown from its atexit() handler. If the node's private '/dev'
or '/run/systemd/journal' mount has already been removed, the
host-side /dev/log or /run/systemd/journal/dev-log sockets will
be removed instead!

Since non-persistent (mount) namespaces are automatically
destroyed by the kernel when the last process referencing them
is killed, we should simply rely on that behavior instead of
explicitly (and prematurely) unmounting a node's private
directories during shutdown.

Signed-off-by: Gabriel Somlo <glsomlo@cert.org>