### PR TITLE
gui: exec.tcl: cache local IP address across calls to getMyIP

### DIFF
--- a/gui/exec.tcl
+++ b/gui/exec.tcl
@@ -782,14 +782,17 @@ proc manageCPUwindow {xpos ypos start} {
 }
 
 proc getMyIP { } {
-    if { [catch {set theServer [socket -server none -myaddr \
-                                [info hostname] 0]} ] } {
-        return "127.0.0.1"
+    variable myIP
+    if { ![info exists myIP] } {
+	if { [catch {set theServer [socket -server none \
+					   -myaddr [info hostname] 0]} ] } {
+	    set myIP "127.0.0.1"
+	} else {
+	    set myIP [lindex [fconfigure $theServer -sockname] 0]
+	    close $theServer
+	}
     }
-    set myIP [lindex [fconfigure $theServer -sockname] 0]
-    close $theServer
     return $myIP
-	
 }
 
 # display all values stored in cpu usage history for each server


### PR DESCRIPTION
Modify getMyIP to cache the local machine's IP address, and
return it without further accessing of the underlying resolver
libraries during subsequent invocations.

getMyIP is called roughly once a second from within monitor_loop
when refreshing CPU utilization in the bottom-right corner of
the GUI window. Other, dedicated CPU usage windows might also
call getMyIP at regular intervals.

With systemd commit cda458a54 (between v232 and v233), the
implementation of gethostbyname4_r() was updated to a more
intransigently standard-compliant error reporting convention,
which in turn causes glibc to retry in a more labor intensive
way (see https://github.com/systemd/systemd/pull/5359).

Under certain circumstances depending on the local hostname
and IP configuration, the glibc/systemd back-end resolver
routines triggered by getMyIP's call to [socket ...] and
[fconfigure ...] end up taking long enough to noticeably slow
down refreshing the main core-gui window, to the point where
interaction with the GUI becomes difficult.

Signed-off-by: Gabriel Somlo <glsomlo@cert.org>