### PR TITLE
[Ovs|LxBr]Net:linkconfig: add netem loss, duplicate pct. only if positive

### DIFF
--- a/daemon/core/netns/openvswitch.py
+++ b/daemon/core/netns/openvswitch.py
@@ -258,10 +258,10 @@ class OvsNet(PyCoreNet):
         if jitter is not None:
             netem += ["%sus" % jitter, "25%"]
 
-        if loss is not None:
+        if loss is not None and loss > 0:
             netem += ["loss", "%s%%" % min(loss, 100)]
 
-        if duplicate is not None:
+        if duplicate is not None and duplicate > 0:
             netem += ["duplicate", "%s%%" % min(duplicate, 100)]
 
         if delay <= 0 and jitter <= 0 and loss <= 0 and duplicate <= 0:

--- a/daemon/core/netns/vnet.py
+++ b/daemon/core/netns/vnet.py
@@ -486,9 +486,9 @@ class LxBrNet(PyCoreNet):
             else:
                 netem += ["%sus" % jitter, "25%"]
 
-        if loss is not None:
+        if loss is not None and loss > 0:
             netem += ["loss", "%s%%" % min(loss, 100)]
-        if duplicate is not None:
+        if duplicate is not None and duplicate > 0:
             netem += ["duplicate", "%s%%" % min(duplicate, 100)]
         if delay <= 0 and jitter <= 0 and loss <= 0 and duplicate <= 0:
             # possibly remove netem if it exists and parent queue wasn't removed


### PR DESCRIPTION
Make sure to only include loss and/or duplicate percentage values
if they are non-zero, to avoid 'tc' from erroring out.

As of iproute2 commit 927e3cfb5, percentage arguments must be
strictly positive: an error is returned if "0[.0]%" values are
provided on the command line.

On large .imn maps with complex networking setups, the symptom is that some network interfaces on some containers will fail to be properly set up (and simply won't end up being present). Addressing the 'tc' failure during configuration will get everything working once again.