### PR TITLE
Fixes for 5.1 release

### DIFF
--- a/daemon/scripts/core-daemon
+++ b/daemon/scripts/core-daemon
@@ -7,6 +7,7 @@ message handlers are defined and some support for sending messages.
 
 import ConfigParser
 import optparse
+import os
 import sys
 import time
 
@@ -111,6 +112,9 @@ def main():
 
     :return: nothing
     """
+    # set umask to 0
+    os.umask(0)
+
     # get a configuration merged from config file and command-line arguments
     cfg, args = get_merged_config("%s/core.conf" % constants.CORE_CONF_DIR)
     for a in args:

--- a/packaging/rpm/core.spec.in
+++ b/packaging/rpm/core.spec.in
@@ -24,7 +24,7 @@ building virtual networks using Linux network namespace containers and bridging.
 Summary:	Common Open Research Emulator daemon back-end
 Group:		System Tools
 Requires:	bash bridge-utils ebtables iproute libev python net-tools
-Requires:	python2-logzero python-enum34
+Requires:	python-enum34
 %if 0%{?el6}
 Requires: procps
 %else
@@ -38,7 +38,7 @@ Requires: iproute-tc
 %endif
 BuildRequires:	make automake autoconf libev-devel python-devel bridge-utils ebtables iproute net-tools ImageMagick help2man
 BuildRequires:	python2-pytest-runner python2-sphinx
-BuildRequires:	python2-logzero python-enum34
+BuildRequires:	python-enum34
 %if 0%{?el6}
 BuildRequires: procps
 %else
@@ -98,8 +98,8 @@ sed -i 's/emane_realtime = True/emane_realtime = False/' /etc/core/core.conf
 if [ "$1" -eq 0 ]; then
     systemctl stop core-daemon.service > /dev/null 2>&1 || true
 
-    if [ -x @SBINDIR@/core-cleanup ]; then
-        @SBINDIR@/core-cleanup > /dev/null 2>&1 || true
+    if [ -x %{_bindir}/core-cleanup ]; then
+        %{_bindir}/core-cleanup > /dev/null 2>&1 || true
     fi
 fi
 
@@ -108,231 +108,69 @@ fi
 %files gui
 %{_bindir}/core-gui
 %dir @CORE_LIB_DIR@
+@CORE_LIB_DIR@/*.tcl
 %dir @CORE_LIB_DIR@/addons
-@CORE_LIB_DIR@/addons/ipsecservice.tcl
-@CORE_LIB_DIR@/annotations.tcl
-@CORE_LIB_DIR@/api.tcl
-@CORE_LIB_DIR@/canvas.tcl
-@CORE_LIB_DIR@/cfgparse.tcl
-@CORE_LIB_DIR@/core-bsd-cleanup.sh
-@CORE_LIB_DIR@/core.tcl
-@CORE_LIB_DIR@/debug.tcl
-@CORE_LIB_DIR@/editor.tcl
-@CORE_LIB_DIR@/exceptions.tcl
-@CORE_LIB_DIR@/exec.tcl
-@CORE_LIB_DIR@/filemgmt.tcl
-@CORE_LIB_DIR@/gpgui.tcl
-@CORE_LIB_DIR@/graph_partitioning.tcl
-@CORE_LIB_DIR@/help.tcl
-%{_datadir}/applications/core-gui.desktop
-%{_datadir}/pixmaps/core-gui.xpm
+@CORE_LIB_DIR@/addons/*
+%{_datadir}/applications/*
+%{_datadir}/pixmaps/*
 %dir %{_datadir}/%{name}
 %dir %{_datadir}/%{name}/icons
 %dir %{_datadir}/%{name}/icons/normal
-%{_datadir}/%{name}/icons/normal/antenna.gif
-%{_datadir}/%{name}/icons/normal/ap.gif
-%{_datadir}/%{name}/icons/normal/core-icon.png
-%{_datadir}/%{name}/icons/normal/core-icon.xbm
-%{_datadir}/%{name}/icons/normal/core-logo-275x75.gif
-%{_datadir}/%{name}/icons/normal/document-properties.gif
-%{_datadir}/%{name}/icons/normal/gps-diagram.xbm
-%{_datadir}/%{name}/icons/normal/host.gif
-%{_datadir}/%{name}/icons/normal/hub.gif
-%{_datadir}/%{name}/icons/normal/lanswitch.gif
-%{_datadir}/%{name}/icons/normal/mdr.gif
-%{_datadir}/%{name}/icons/normal/oval.gif
-%{_datadir}/%{name}/icons/normal/pc.gif
-%{_datadir}/%{name}/icons/normal/rj45.gif
-%{_datadir}/%{name}/icons/normal/router_black.gif
-%{_datadir}/%{name}/icons/normal/router.gif
-%{_datadir}/%{name}/icons/normal/router_green.gif
-%{_datadir}/%{name}/icons/normal/router_purple.gif
-%{_datadir}/%{name}/icons/normal/router_red.gif
-%{_datadir}/%{name}/icons/normal/router_yellow.gif
-%{_datadir}/%{name}/icons/normal/simple.xbm
-%{_datadir}/%{name}/icons/normal/text.gif
-%{_datadir}/%{name}/icons/normal/thumb-unknown.gif
-%{_datadir}/%{name}/icons/normal/tunnel.gif
-%{_datadir}/%{name}/icons/normal/wlan.gif
-%{_datadir}/%{name}/icons/normal/xen.gif
+%{_datadir}/%{name}/icons/normal/*
 %dir %{_datadir}/%{name}/icons/svg
-%{_datadir}/%{name}/icons/svg/ap.svg
-%{_datadir}/%{name}/icons/svg/cel.svg
-%{_datadir}/%{name}/icons/svg/hub.svg
-%{_datadir}/%{name}/icons/svg/lanswitch.svg
-%{_datadir}/%{name}/icons/svg/mdr.svg
-%{_datadir}/%{name}/icons/svg/otr.svg
-%{_datadir}/%{name}/icons/svg/rj45.svg
-%{_datadir}/%{name}/icons/svg/router_black.svg
-%{_datadir}/%{name}/icons/svg/router_green.svg
-%{_datadir}/%{name}/icons/svg/router_purple.svg
-%{_datadir}/%{name}/icons/svg/router_red.svg
-%{_datadir}/%{name}/icons/svg/router.svg
-%{_datadir}/%{name}/icons/svg/router_yellow.svg
-%{_datadir}/%{name}/icons/svg/start.svg
-%{_datadir}/%{name}/icons/svg/tunnel.svg
-%{_datadir}/%{name}/icons/svg/vlan.svg
-%{_datadir}/%{name}/icons/svg/xen.svg
+%{_datadir}/%{name}/icons/svg/*
 %dir %{_datadir}/%{name}/icons/tiny
-%{_datadir}/%{name}/icons/tiny/ap.gif
-%{_datadir}/%{name}/icons/tiny/arrow.down.gif
-%{_datadir}/%{name}/icons/tiny/arrow.gif
-%{_datadir}/%{name}/icons/tiny/arrow.up.gif
-%{_datadir}/%{name}/icons/tiny/blank.gif
-%{_datadir}/%{name}/icons/tiny/button.play.gif
-%{_datadir}/%{name}/icons/tiny/button.stop.gif
-%{_datadir}/%{name}/icons/tiny/cel.gif
-%{_datadir}/%{name}/icons/tiny/delete.gif
-%{_datadir}/%{name}/icons/tiny/document-new.gif
-%{_datadir}/%{name}/icons/tiny/document-properties.gif
-%{_datadir}/%{name}/icons/tiny/document-save.gif
-%{_datadir}/%{name}/icons/tiny/edit-delete.gif
-%{_datadir}/%{name}/icons/tiny/eraser.gif
-%{_datadir}/%{name}/icons/tiny/fileopen.gif
-%{_datadir}/%{name}/icons/tiny/folder.gif
-%{_datadir}/%{name}/icons/tiny/host.gif
-%{_datadir}/%{name}/icons/tiny/hub.gif
-%{_datadir}/%{name}/icons/tiny/lanswitch.gif
-%{_datadir}/%{name}/icons/tiny/link.gif
-%{_datadir}/%{name}/icons/tiny/marker.gif
-%{_datadir}/%{name}/icons/tiny/mdr.gif
-%{_datadir}/%{name}/icons/tiny/mobility.gif
-%{_datadir}/%{name}/icons/tiny/moboff.gif
-%{_datadir}/%{name}/icons/tiny/observe.gif
-%{_datadir}/%{name}/icons/tiny/oval.gif
-%{_datadir}/%{name}/icons/tiny/pc.gif
-%{_datadir}/%{name}/icons/tiny/ping.gif
-%{_datadir}/%{name}/icons/tiny/plot.gif
-%{_datadir}/%{name}/icons/tiny/rectangle.gif
-%{_datadir}/%{name}/icons/tiny/rj45.gif
-%{_datadir}/%{name}/icons/tiny/router_black.gif
-%{_datadir}/%{name}/icons/tiny/router.gif
-%{_datadir}/%{name}/icons/tiny/router_green.gif
-%{_datadir}/%{name}/icons/tiny/router_purple.gif
-%{_datadir}/%{name}/icons/tiny/router_red.gif
-%{_datadir}/%{name}/icons/tiny/router_yellow.gif
-%{_datadir}/%{name}/icons/tiny/run.gif
-%{_datadir}/%{name}/icons/tiny/script_pause.gif
-%{_datadir}/%{name}/icons/tiny/script_play.gif
-%{_datadir}/%{name}/icons/tiny/script_stop.gif
-%{_datadir}/%{name}/icons/tiny/select.gif
-%{_datadir}/%{name}/icons/tiny/start.gif
-%{_datadir}/%{name}/icons/tiny/stock_connect.gif
-%{_datadir}/%{name}/icons/tiny/stock_disconnect.gif
-%{_datadir}/%{name}/icons/tiny/stop.gif
-%{_datadir}/%{name}/icons/tiny/text.gif
-%{_datadir}/%{name}/icons/tiny/trace.gif
-%{_datadir}/%{name}/icons/tiny/tunnel.gif
-%{_datadir}/%{name}/icons/tiny/twonode.gif
-%{_datadir}/%{name}/icons/tiny/view-refresh.gif
-%{_datadir}/%{name}/icons/tiny/wlan.gif
-%{_datadir}/%{name}/icons/tiny/xen.gif
-@CORE_LIB_DIR@/initgui.tcl
-@CORE_LIB_DIR@/ipv4.tcl
-@CORE_LIB_DIR@/ipv6.tcl
-@CORE_LIB_DIR@/linkcfg.tcl
-@CORE_LIB_DIR@/mobility.tcl
-@CORE_LIB_DIR@/nodecfg.tcl
-@CORE_LIB_DIR@/nodes.tcl
-@CORE_LIB_DIR@/ns2imunes.tcl
-@CORE_LIB_DIR@/plugins.tcl
-@CORE_LIB_DIR@/services.tcl
-@CORE_LIB_DIR@/tooltips.tcl
-@CORE_LIB_DIR@/topogen.tcl
-@CORE_LIB_DIR@/traffic.tcl
-@CORE_LIB_DIR@/util.tcl
-@CORE_LIB_DIR@/version.tcl
-@CORE_LIB_DIR@/widget.tcl
-@CORE_LIB_DIR@/wlanscript.tcl
-@CORE_LIB_DIR@/wlan.tcl
+%{_datadir}/%{name}/icons/tiny/*
 %dir %{_datadir}/%{name}/examples
 %dir %{_datadir}/%{name}/examples/configs
-%{_datadir}/%{name}/examples/configs/sample10-kitchen-sink.imn
-%{_datadir}/%{name}/examples/configs/sample1-bg.gif
-%{_datadir}/%{name}/examples/configs/sample1.imn
-%{_datadir}/%{name}/examples/configs/sample1.scen
-%{_datadir}/%{name}/examples/configs/sample2-ssh.imn
-%{_datadir}/%{name}/examples/configs/sample3-bgp.imn
-%{_datadir}/%{name}/examples/configs/sample4-bg.jpg
-%{_datadir}/%{name}/examples/configs/sample4-nrlsmf.imn
-%{_datadir}/%{name}/examples/configs/sample4.scen
-%{_datadir}/%{name}/examples/configs/sample5-mgen.imn
-%{_datadir}/%{name}/examples/configs/sample6-emane-rfpipe.imn
-%{_datadir}/%{name}/examples/configs/sample7-emane-ieee80211abg.imn
-%{_datadir}/%{name}/examples/configs/sample8-ipsec-service.imn
-%{_datadir}/%{name}/examples/configs/sample9-vpn.imn
-%doc  %{_mandir}/man1/core-gui.1.gz
+%{_datadir}/%{name}/examples/configs/*
+%doc %{_mandir}/man1/core-gui.1.gz
 
 %files daemon
-%config @CORE_CONF_DIR@/core.conf
-%config @CORE_CONF_DIR@/perflogserver.conf
-%config @CORE_CONF_DIR@/xen.conf
+%{_bindir}/core-cleanup
+%{_bindir}/core-daemon
+%{_bindir}/core-manage
+%{_bindir}/coresendmsg
+%{_bindir}/netns
+%{_bindir}/vcmd
+%{_bindir}/vnoded
+%{python_sitelib}/*
+%dir @CORE_CONF_DIR@
+%config @CORE_CONF_DIR@/*
+%{_sysconfdir}/systemd/system/core-daemon.service
 %dir %{_datadir}/%{name}
 %dir %{_datadir}/%{name}/examples
 %{_datadir}/%{name}/examples/controlnet_updown
-%dir %{_datadir}/%{name}/examples/corens3
-%{_datadir}/%{name}/examples/corens3/ns3lte.py*
-%{_datadir}/%{name}/examples/corens3/ns3wifi.py*
-%{_datadir}/%{name}/examples/corens3/ns3wifirandomwalk.py*
-%{_datadir}/%{name}/examples/corens3/ns3wimax.py*
-%{_datadir}/%{name}/examples/emanemanifest2core.py*
-%{_datadir}/%{name}/examples/emanemodel2core.py*
-%{_datadir}/%{name}/examples/findcore.py*
+%{_datadir}/%{name}/examples/*.py*
+%dir %{_datadir}/%{name}/examples/api
+%{_datadir}/%{name}/examples/api/*
 %dir %{_datadir}/%{name}/examples/hooks
-%{_datadir}/%{name}/examples/hooks/configuration_hook.sh
-%{_datadir}/%{name}/examples/hooks/datacollect_hook.sh
-%{_datadir}/%{name}/examples/hooks/perflogserver.py*
-%{_datadir}/%{name}/examples/hooks/perflogstart.sh
-%{_datadir}/%{name}/examples/hooks/perflogstop.sh
-%{_datadir}/%{name}/examples/hooks/sessiondatacollect.sh
-%{_datadir}/%{name}/examples/hooks/timesyncstart.sh
-%{_datadir}/%{name}/examples/hooks/timesyncstop.sh
+%{_datadir}/%{name}/examples/hooks/*
+%dir %{_datadir}/%{name}/examples/myemane
+%{_datadir}/%{name}/examples/myemane/*
 %dir %{_datadir}/%{name}/examples/myservices
-%{_datadir}/%{name}/examples/myservices/__init__.py*
-%{_datadir}/%{name}/examples/myservices/README.txt
-%{_datadir}/%{name}/examples/myservices/sample.py*
+%{_datadir}/%{name}/examples/myservices/*
 %dir %{_datadir}/%{name}/examples/netns
-%{_datadir}/%{name}/examples/netns/basicrange.py*
-%{_datadir}/%{name}/examples/netns/daemonnodes.py*
-%{_datadir}/%{name}/examples/netns/distributed.py*
-%{_datadir}/%{name}/examples/netns/emane80211.py*
-%{_datadir}/%{name}/examples/netns/howmanynodes.py*
-%{_datadir}/%{name}/examples/netns/iperf-performance-chain.py*
-%{_datadir}/%{name}/examples/netns/iperf-performance.sh
-%{_datadir}/%{name}/examples/netns/ospfmanetmdrtest.py*
-%{_datadir}/%{name}/examples/netns/switch.py*
-%{_datadir}/%{name}/examples/netns/switchtest.py*
-%{_datadir}/%{name}/examples/netns/twonodes.sh
-%{_datadir}/%{name}/examples/netns/wlanemanetests.py*
-%{_datadir}/%{name}/examples/netns/wlantest.py*
+%{_datadir}/%{name}/examples/netns/*
 %dir %{_datadir}/%{name}/examples/services
-%{_datadir}/%{name}/examples/services/sampleFirewall
-%{_datadir}/%{name}/examples/services/sampleIPsec
-%{_datadir}/%{name}/examples/services/sampleVPNClient
-%{_datadir}/%{name}/examples/services/sampleVPNServer
-%{_datadir}/%{name}/examples/stopsession.py*
-%doc  %{_mandir}/man1/core-cleanup.1.gz
-%doc  %{_mandir}/man1/core-daemon.1.gz
-%doc  %{_mandir}/man1/core-manage.1.gz
-%doc  %{_mandir}/man1/coresendmsg.1.gz
-%doc  %{_mandir}/man1/core-xen-cleanup.1.gz
-%doc  %{_mandir}/man1/netns.1.gz
-%doc  %{_mandir}/man1/vcmd.1.gz
-%doc  %{_mandir}/man1/vnoded.1.gz
-/etc/logrotate.d/core-daemon
-/etc/systemd/system/core-daemon.service
-%{python_sitearch}/*
-%{python_sitelib}/*
-%{_sbindir}/core-cleanup
-%{_sbindir}/core-daemon
-%{_sbindir}/core-manage
-%{_sbindir}/coresendmsg
-%{_sbindir}/core-xen-cleanup
-%{_sbindir}/netns
-%{_sbindir}/vcmd
-%{_sbindir}/vnoded
+%{_datadir}/%{name}/examples/services/*
+%dir %{_datadir}/%{name}/examples/tdma
+%{_datadir}/%{name}/examples/tdma/*
+%dir %{_datadir}/corens3
+%dir %{_datadir}/corens3/examples
+%{_datadir}/corens3/examples/*
+%doc %{_mandir}/man1/core-cleanup.1.gz
+%doc %{_mandir}/man1/core-daemon.1.gz
+%doc %{_mandir}/man1/core-manage.1.gz
+%doc %{_mandir}/man1/coresendmsg.1.gz
+%doc %{_mandir}/man1/core-xen-cleanup.1.gz
+%doc %{_mandir}/man1/netns.1.gz
+%doc %{_mandir}/man1/vcmd.1.gz
+%doc %{_mandir}/man1/vnoded.1.gz
 
 %changelog
+* Fri May 25 2018 Gabriel Somlo <glsomlo@cert.org> - 5.1
+- update RPM spec file to match 5.1 release
 * Mon Nov 20 2017 Gabriel Somlo <glsomlo@cert.org> - 5.0
 - update RPM spec file to match 5.0 release
 * Fri Sep 01 2017 CORE Developers <core-dev@nrl.navy.mil> - 5.0


### PR DESCRIPTION
First, there's a patch updating the RPM spec file to build the new 5.1 release.

The second patch is a bit more important: as it turns out, the old (5.0, 4.8, etc.) version of core-daemon used to set umask=0 globally during its call to os.daemonize(). That turns out to have been a good thing, as it caused all privatedir folders to be created with 777 permissions. Since they're all owned by root, that's important to in-container daemons that default to running as non-root users (e.g. named:named, toranon for TOR, and so on). On the host system, various folders related to these daemons would be owned by their respective users. Inside a CORE container, with privatedirs owned by root, anything less than 777 would prevent these daemons from writing to their dedicated log directories.

The patch restores the global umask=0 setting in the new core-daemon code.

Thanks much,
--Gabriel