### PR TITLE
allow passing in a Session class to CoreEmu.create_session() helper

### DIFF
--- a/daemon/core/emulator/coreemu.py
+++ b/daemon/core/emulator/coreemu.py
@@ -853,12 +853,13 @@ class CoreEmu(object):
         for session in sessions.itervalues():
             session.shutdown()
 
-    def create_session(self, _id=None, master=True):
+    def create_session(self, _id=None, master=True, _cls=EmuSession):
         """
         Create a new CORE session, set to master if running standalone.
 
         :param int _id: session id for new session
         :param bool master: sets session to master
+        :param class _cls: EmuSession class to use
         :return: created session
         :rtype: EmuSession
         """
@@ -870,7 +871,7 @@ class CoreEmu(object):
                 if session_id not in self.sessions:
                     break
 
-        session = EmuSession(session_id, config=self.config)
+        session = _cls(session_id, config=self.config)
         logger.info("created session: %s", session_id)
         if master:
             session.master = True


### PR DESCRIPTION
This allows for a Python script that subclasses the EmuSession object.

For example:
```python
class HipSession(EmuSession):
    ''' ...insert custom code here
    '''

# use the create_session() helper with our custom class
session = coreemu.create_session(_cls=HipSession)
# now we can easily connect the GUI to our Session
```

- allow passing in a Session class to CoreEmu.create_session() helper

  Signed-off-by: Jeff Ahrenholz <siliconja@users.noreply.github.com>