### PR TITLE
quiet core-daemon by replacing warn messages with debug

### DIFF
--- a/daemon/core/emane/commeffect.py
+++ b/daemon/core/emane/commeffect.py
@@ -18,7 +18,7 @@ except ImportError:
     try:
         from emanesh.events.commeffectevent import CommEffectEvent
     except ImportError:
-        logger.warn("compatible emane python bindings not installed")
+        logger.debug("compatible emane python bindings not installed")
 
 
 def convert_none(x):

--- a/daemon/core/emane/emanemanager.py
+++ b/daemon/core/emane/emanemanager.py
@@ -42,7 +42,7 @@ except ImportError:
         from emanesh.events import LocationEvent
         from emanesh.events.eventserviceexception import EventServiceException
     except ImportError:
-        logger.warn("compatible emane python bindings not installed")
+        logger.debug("compatible emane python bindings not installed")
 
 EMANE_MODELS = [
     EmaneRfPipeModel,

--- a/daemon/core/emane/emanemanifest.py
+++ b/daemon/core/emane/emanemanifest.py
@@ -9,7 +9,7 @@ except ImportError:
     try:
         from emanesh import manifest
     except ImportError:
-        logger.warn("compatible emane python bindings not installed")
+        logger.debug("compatible emane python bindings not installed")
 
 
 def _type_value(config_type):

--- a/daemon/core/emane/nodes.py
+++ b/daemon/core/emane/nodes.py
@@ -16,7 +16,7 @@ except ImportError:
     try:
         from emanesh.events import LocationEvent
     except ImportError:
-        logger.warn("compatible emane python bindings not installed")
+        logger.debug("compatible emane python bindings not installed")
 
 
 class EmaneNet(PyCoreNet):

--- a/daemon/core/misc/nodeutils.py
+++ b/daemon/core/misc/nodeutils.py
@@ -13,7 +13,7 @@ def _log_map():
         name = None
         if value:
             name = value.__name__
-        logger.info("node type (%s) - class (%s)", key.name, name)
+        logger.debug("node type (%s) - class (%s)", key.name, name)
 
 
 def _convert_map(x, y):

--- a/daemon/core/service.py
+++ b/daemon/core/service.py
@@ -223,7 +223,7 @@ class ServiceManager(object):
         :return: nothing
         """
         name = service.name
-        logger.info("loading service: class(%s) name(%s)", service.__name__, name)
+        logger.debug("loading service: class(%s) name(%s)", service.__name__, name)
 
         # avoid duplicate services
         if name in cls.services:
@@ -232,7 +232,7 @@ class ServiceManager(object):
         # validate dependent executables are present
         for executable in service.executables:
             if not which(executable):
-                logger.warn("service(%s) missing executable: %s", service.name, executable)
+                logger.debug("service(%s) missing executable: %s", service.name, executable)
                 raise ValueError("service(%s) missing executable: %s" % (service.name, executable))
 
         # make service available
@@ -269,7 +269,7 @@ class ServiceManager(object):
                 cls.add(service)
             except ValueError as e:
                 service_errors.append(service.name)
-                logger.warn("not loading service: %s", e)
+                logger.debug("not loading service: %s", e)
         return service_errors
 
 

--- a/daemon/core/services/dockersvc.py
+++ b/daemon/core/services/dockersvc.py
@@ -104,7 +104,7 @@ from core.service import ServiceManager
 try:
     from docker import Client
 except ImportError:
-    logger.warn("missing python docker bindings")
+    logger.debug("missing python docker bindings")
 
 
 class DockerService(CoreService):


### PR DESCRIPTION
I like to run core-daemon in a terminal and watch the output. CORE 5.2 versus 4.8 will spam the terminal with lots of messages on startup. For CORE Python scripts this happens for each session.

At the moment I’m not installing EMANE (the source of some messages), and I’m not installing all dependencies for every possible service (the source of some more messages).

This seems like debug-level messaging to me.

Before (this is simply starting the daemon, and NOT running anything yet):

```
jeffa@snow:~$ sudo core-daemon
2018-10-09 10:19:06,193 - WARNING - nodes:<module> - compatible emane python bindings not installed
2018-10-09 10:19:06,197 - WARNING - emanemanifest:<module> - compatible emane python bindings not installed
2018-10-09 10:19:06,213 - WARNING - commeffect:<module> - compatible emane python bindings not installed
2018-10-09 10:19:06,214 - WARNING - emanemanager:<module> - compatible emane python bindings not installed
2018-10-09 10:19:06,217 - INFO - core-daemon:banner - CORE daemon v.5.2 started Tue Oct  9 10:19:06 2018
2018-10-09 10:19:06,217 - INFO - nodeutils:_log_map - node type (TAP_BRIDGE) - class (GreTapBridge)
2018-10-09 10:19:06,217 - INFO - nodeutils:_log_map - node type (DEFAULT) - class (CoreNode)
2018-10-09 10:19:06,217 - INFO - nodeutils:_log_map - node type (WIRELESS_LAN) - class (WlanNode)
2018-10-09 10:19:06,218 - INFO - nodeutils:_log_map - node type (EMANE_NET) - class (EmaneNet)
2018-10-09 10:19:06,218 - INFO - nodeutils:_log_map - node type (EMANE) - class (EmaneNode)
2018-10-09 10:19:06,218 - INFO - nodeutils:_log_map - node type (PHYSICAL) - class (PhysicalNode)
2018-10-09 10:19:06,218 - INFO - nodeutils:_log_map - node type (CONTROL_NET) - class (CtrlNet)
2018-10-09 10:19:06,218 - INFO - nodeutils:_log_map - node type (HUB) - class (HubNode)
2018-10-09 10:19:06,218 - INFO - nodeutils:_log_map - node type (TUNNEL) - class (TunnelNode)
2018-10-09 10:19:06,218 - INFO - nodeutils:_log_map - node type (PEER_TO_PEER) - class (PtpNet)
2018-10-09 10:19:06,218 - INFO - nodeutils:_log_map - node type (RJ45) - class (RJ45Node)
2018-10-09 10:19:06,218 - INFO - nodeutils:_log_map - node type (SWITCH) - class (SwitchNode)
2018-10-09 10:19:06,218 - INFO - nodeutils:_log_map - node type (KTUNNEL) - class (None)
2018-10-09 10:19:06,218 - INFO - nodeutils:_log_map - node type (TBD) - class (None)
2018-10-09 10:19:06,224 - WARNING - dockersvc:<module> - missing python docker bindings
2018-10-09 10:19:06,225 - INFO - service:add - loading service: class(XorpBgp) name(XORP_BGP)
2018-10-09 10:19:06,225 - WARNING - service:add - service(XORP_BGP) missing executable: xorp_rtrmgr
2018-10-09 10:19:06,225 - WARNING - service:add_services - not loading service: service(XORP_BGP) missing executable: xorp_rtrmgr
2018-10-09 10:19:06,225 - INFO - service:add - loading service: class(XorpOlsr) name(XORP_OLSR)
2018-10-09 10:19:06,225 - WARNING - service:add - service(XORP_OLSR) missing executable: xorp_rtrmgr
2018-10-09 10:19:06,225 - WARNING - service:add_services - not loading service: service(XORP_OLSR) missing executable: xorp_rtrmgr
2018-10-09 10:19:06,225 - INFO - service:add - loading service: class(XorpOspfv2) name(XORP_OSPFv2)
2018-10-09 10:19:06,225 - WARNING - service:add - service(XORP_OSPFv2) missing executable: xorp_rtrmgr
2018-10-09 10:19:06,225 - WARNING - service:add_services - not loading service: service(XORP_OSPFv2) missing executable: xorp_rtrmgr
2018-10-09 10:19:06,225 - INFO - service:add - loading service: class(XorpOspfv3) name(XORP_OSPFv3)
2018-10-09 10:19:06,225 - WARNING - service:add - service(XORP_OSPFv3) missing executable: xorp_rtrmgr
2018-10-09 10:19:06,225 - WARNING - service:add_services - not loading service: service(XORP_OSPFv3) missing executable: xorp_rtrmgr
2018-10-09 10:19:06,226 - INFO - service:add - loading service: class(XorpPimSm4) name(XORP_PIMSM4)
2018-10-09 10:19:06,226 - WARNING - service:add - service(XORP_PIMSM4) missing executable: xorp_rtrmgr
2018-10-09 10:19:06,226 - WARNING - service:add_services - not loading service: service(XORP_PIMSM4) missing executable: xorp_rtrmgr
2018-10-09 10:19:06,226 - INFO - service:add - loading service: class(XorpPimSm6) name(XORP_PIMSM6)
2018-10-09 10:19:06,226 - WARNING - service:add - service(XORP_PIMSM6) missing executable: xorp_rtrmgr
2018-10-09 10:19:06,226 - WARNING - service:add_services - not loading service: service(XORP_PIMSM6) missing executable: xorp_rtrmgr
2018-10-09 10:19:06,226 - INFO - service:add - loading service: class(XorpRip) name(XORP_RIP)
2018-10-09 10:19:06,226 - WARNING - service:add - service(XORP_RIP) missing executable: xorp_rtrmgr
2018-10-09 10:19:06,226 - WARNING - service:add_services - not loading service: service(XORP_RIP) missing executable: xorp_rtrmgr
2018-10-09 10:19:06,226 - INFO - service:add - loading service: class(XorpRipng) name(XORP_RIPNG)
2018-10-09 10:19:06,226 - WARNING - service:add - service(XORP_RIPNG) missing executable: xorp_rtrmgr
2018-10-09 10:19:06,226 - WARNING - service:add_services - not loading service: service(XORP_RIPNG) missing executable: xorp_rtrmgr
2018-10-09 10:19:06,226 - INFO - service:add - loading service: class(XorpRtrmgr) name(xorp_rtrmgr)
2018-10-09 10:19:06,226 - WARNING - service:add - service(xorp_rtrmgr) missing executable: xorp_rtrmgr
2018-10-09 10:19:06,226 - WARNING - service:add_services - not loading service: service(xorp_rtrmgr) missing executable: xorp_rtrmgr
2018-10-09 10:19:06,226 - INFO - service:add - loading service: class(Ucarp) name(ucarp)
2018-10-09 10:19:06,226 - INFO - service:add - loading service: class(Arouted) name(arouted)
2018-10-09 10:19:06,227 - WARNING - service:add - service(arouted) missing executable: arouted
2018-10-09 10:19:06,227 - WARNING - service:add_services - not loading service: service(arouted) missing executable: arouted
2018-10-09 10:19:06,227 - INFO - service:add - loading service: class(MgenActor) name(MgenActor)
2018-10-09 10:19:06,227 - WARNING - service:add - service(MgenActor) missing executable: mgen
2018-10-09 10:19:06,227 - WARNING - service:add_services - not loading service: service(MgenActor) missing executable: mgen
2018-10-09 10:19:06,227 - INFO - service:add - loading service: class(MgenSinkService) name(MGEN_Sink)
2018-10-09 10:19:06,227 - WARNING - service:add - service(MGEN_Sink) missing executable: mgen
2018-10-09 10:19:06,227 - WARNING - service:add_services - not loading service: service(MGEN_Sink) missing executable: mgen
2018-10-09 10:19:06,227 - INFO - service:add - loading service: class(NrlNhdp) name(NHDP)
2018-10-09 10:19:06,227 - WARNING - service:add - service(NHDP) missing executable: nrlnhdp
2018-10-09 10:19:06,227 - WARNING - service:add_services - not loading service: service(NHDP) missing executable: nrlnhdp
2018-10-09 10:19:06,227 - INFO - service:add - loading service: class(NrlOlsr) name(OLSR)
2018-10-09 10:19:06,227 - WARNING - service:add - service(OLSR) missing executable: nrlolsrd
2018-10-09 10:19:06,227 - WARNING - service:add_services - not loading service: service(OLSR) missing executable: nrlolsrd
2018-10-09 10:19:06,228 - INFO - service:add - loading service: class(NrlOlsrv2) name(OLSRv2)
2018-10-09 10:19:06,228 - WARNING - service:add - service(OLSRv2) missing executable: nrlolsrv2
2018-10-09 10:19:06,228 - WARNING - service:add_services - not loading service: service(OLSRv2) missing executable: nrlolsrv2
2018-10-09 10:19:06,228 - INFO - service:add - loading service: class(NrlSmf) name(SMF)
2018-10-09 10:19:06,228 - WARNING - service:add - service(SMF) missing executable: nrlsmf
2018-10-09 10:19:06,228 - WARNING - service:add_services - not loading service: service(SMF) missing executable: nrlsmf
2018-10-09 10:19:06,228 - INFO - service:add - loading service: class(OlsrOrg) name(OLSRORG)
2018-10-09 10:19:06,228 - WARNING - service:add - service(OLSRORG) missing executable: olsrd
2018-10-09 10:19:06,229 - WARNING - service:add_services - not loading service: service(OLSRORG) missing executable: olsrd
2018-10-09 10:19:06,229 - INFO - service:add - loading service: class(OvsService) name(OvsService)
2018-10-09 10:19:06,229 - WARNING - service:add - service(OvsService) missing executable: ovs-ofctl
2018-10-09 10:19:06,229 - WARNING - service:add_services - not loading service: service(OvsService) missing executable: ovs-ofctl
2018-10-09 10:19:06,229 - INFO - service:add - loading service: class(RyuService) name(ryuService)
2018-10-09 10:19:06,229 - WARNING - service:add - service(ryuService) missing executable: ryu-manager
2018-10-09 10:19:06,229 - WARNING - service:add_services - not loading service: service(ryuService) missing executable: ryu-manager
2018-10-09 10:19:06,229 - INFO - service:add - loading service: class(Bird) name(bird)
2018-10-09 10:19:06,229 - WARNING - service:add - service(bird) missing executable: bird
2018-10-09 10:19:06,229 - WARNING - service:add_services - not loading service: service(bird) missing executable: bird
2018-10-09 10:19:06,229 - INFO - service:add - loading service: class(BirdBgp) name(BIRD_BGP)
2018-10-09 10:19:06,229 - WARNING - service:add - service(BIRD_BGP) missing executable: bird
2018-10-09 10:19:06,229 - WARNING - service:add_services - not loading service: service(BIRD_BGP) missing executable: bird
2018-10-09 10:19:06,229 - INFO - service:add - loading service: class(BirdOspf) name(BIRD_OSPFv2)
2018-10-09 10:19:06,229 - WARNING - service:add - service(BIRD_OSPFv2) missing executable: bird
2018-10-09 10:19:06,230 - WARNING - service:add_services - not loading service: service(BIRD_OSPFv2) missing executable: bird
2018-10-09 10:19:06,230 - INFO - service:add - loading service: class(BirdRadv) name(BIRD_RADV)
2018-10-09 10:19:06,230 - WARNING - service:add - service(BIRD_RADV) missing executable: bird
2018-10-09 10:19:06,230 - WARNING - service:add_services - not loading service: service(BIRD_RADV) missing executable: bird
2018-10-09 10:19:06,230 - INFO - service:add - loading service: class(BirdRip) name(BIRD_RIP)
2018-10-09 10:19:06,230 - WARNING - service:add - service(BIRD_RIP) missing executable: bird
2018-10-09 10:19:06,230 - WARNING - service:add_services - not loading service: service(BIRD_RIP) missing executable: bird
2018-10-09 10:19:06,230 - INFO - service:add - loading service: class(BirdStatic) name(BIRD_static)
2018-10-09 10:19:06,230 - WARNING - service:add - service(BIRD_static) missing executable: bird
2018-10-09 10:19:06,230 - WARNING - service:add_services - not loading service: service(BIRD_static) missing executable: bird
2018-10-09 10:19:06,230 - INFO - service:add - loading service: class(Babel) name(Babel)
2018-10-09 10:19:06,230 - INFO - service:add - loading service: class(Bgp) name(BGP)
2018-10-09 10:19:06,230 - INFO - service:add - loading service: class(Ospfv2) name(OSPFv2)
2018-10-09 10:19:06,230 - INFO - service:add - loading service: class(Ospfv3) name(OSPFv3)
2018-10-09 10:19:06,230 - INFO - service:add - loading service: class(Ospfv3mdr) name(OSPFv3MDR)
2018-10-09 10:19:06,230 - INFO - service:add - loading service: class(Rip) name(RIP)
2018-10-09 10:19:06,231 - INFO - service:add - loading service: class(Ripng) name(RIPNG)
2018-10-09 10:19:06,231 - INFO - service:add - loading service: class(Xpimd) name(Xpimd)
2018-10-09 10:19:06,231 - INFO - service:add - loading service: class(Zebra) name(zebra)
2018-10-09 10:19:06,231 - INFO - service:add - loading service: class(EmaneTransportService) name(transportd)
2018-10-09 10:19:06,231 - WARNING - service:add - service(transportd) missing executable: emanetransportd
2018-10-09 10:19:06,231 - WARNING - service:add_services - not loading service: service(transportd) missing executable: emanetransportd
2018-10-09 10:19:06,231 - INFO - service:add - loading service: class(AtdService) name(atd)
2018-10-09 10:19:06,231 - INFO - service:add - loading service: class(DefaultMulticastRouteService) name(DefaultMulticastRoute)
2018-10-09 10:19:06,231 - INFO - service:add - loading service: class(DefaultRouteService) name(DefaultRoute)
2018-10-09 10:19:06,231 - INFO - service:add - loading service: class(DhcpClientService) name(DHCPClient)
2018-10-09 10:19:06,231 - INFO - service:add - loading service: class(DhcpService) name(DHCP)
2018-10-09 10:19:06,231 - INFO - service:add - loading service: class(FtpService) name(FTP)
2018-10-09 10:19:06,232 - INFO - service:add - loading service: class(HttpService) name(HTTP)
2018-10-09 10:19:06,232 - INFO - service:add - loading service: class(IPForwardService) name(IPForward)
2018-10-09 10:19:06,232 - INFO - service:add - loading service: class(PcapService) name(pcap)
2018-10-09 10:19:06,232 - INFO - service:add - loading service: class(RadvdService) name(radvd)
2018-10-09 10:19:06,232 - INFO - service:add - loading service: class(SshService) name(SSH)
2018-10-09 10:19:06,232 - INFO - service:add - loading service: class(StaticRouteService) name(StaticRoute)
2018-10-09 10:19:06,232 - INFO - service:add - loading service: class(UserDefinedService) name(UserDefined)
2018-10-09 10:19:06,232 - INFO - service:add - loading service: class(Firewall) name(Firewall)
2018-10-09 10:19:06,232 - INFO - service:add - loading service: class(IPsec) name(IPsec)
2018-10-09 10:19:06,232 - INFO - service:add - loading service: class(VPNClient) name(VPNClient)
2018-10-09 10:19:06,232 - INFO - service:add - loading service: class(VPNServer) name(VPNServer)
2018-10-09 10:19:06,232 - INFO - service:add - loading service: class(DockerService) name(Docker)
2018-10-09 10:19:06,233 - INFO - core-daemon:cored - server started, listening on: localhost:4038
^C2018-10-09 10:19:21,149 - INFO - coreemu:signal_handler - caught signal: 2
2018-10-09 10:19:21,150 - INFO - coreemu:shutdown - shutting down all sessions
jeffa@snow:~$
```

After:

```
jeffa@snow:~$ sudo core-daemon
2018-10-09 10:21:43,803 - INFO - core-daemon:banner - CORE daemon v.5.2 started Tue Oct  9 10:21:43 2018
2018-10-09 10:21:43,808 - INFO - core-daemon:cored - server started, listening on: localhost:4038
^C2018-10-09 10:21:45,167 - INFO - coreemu:signal_handler - caught signal: 2
2018-10-09 10:21:45,168 - INFO - coreemu:shutdown - shutting down all sessions
jeffa@snow:~$
```
