### PR TITLE
fix core-cleanup script to invoke killall correctly

### DIFF
--- a/daemon/scripts/core-cleanup
+++ b/daemon/scripts/core-cleanup
@@ -33,10 +33,16 @@ if [ "z$2" = "z-l" ]; then
     rm -f /var/log/core-daemon.log
 fi
 
+kaopts="-v"
+killall --help 2>&1 | grep -q namespace
+if [ $? = 0 ]; then
+    kaopts="$kaopts --ns 0"
+fi
+
 vnodedpids=`pidof vnoded`
 if [ "z$vnodedpids" != "z" ]; then
     echo "cleaning up old vnoded processes: $vnodedpids"
-    killall -v -KILL vnoded
+    killall $kaopts -KILL vnoded
     # pause for 1 second for interfaces to disappear
     sleep 1
 fi
@@ -54,7 +60,7 @@ eval "$ifcommand" | awk '
     /^veth[0-9]+\./ {print "removing interface " $1; system("ip link del " $1);}
     /tmp\./    {print "removing interface " $1; system("ip link del " $1);}
     /gt\./     {print "removing interface " $1; system("ip link del " $1);}
-    /b\./ {print "removing bridge " $1; system("ip link set " $1 " down; brctl delbr " $1);}
+    /b\./ {print "removing bridge " $1; system("ip link set " $1 " down; ip link del " $1);}
 '
 
 ebtables -L FORWARD | awk '


### PR DESCRIPTION
Newer versions of killall (I'm using PSmisc 23.1 default with Ubuntu 18.04) require a "--ns" aka "namespace" option in order to properly kill vnoded. Otherwise the script silently fails to clean up anything.

This change allows the **core-cleanup** script to work with either version of killall (old and new) by first checking supported arguments.

Also use ip instead of brctl for destroying CORE-built bridges.

- fix core-cleanup script to invoke killall correctly