### PR TITLE
log warning when node.privatedir() raises an exception

### DIFF
--- a/daemon/core/service.py
+++ b/daemon/core/service.py
@@ -466,7 +466,12 @@ class CoreServices(object):
 
         # create service directories
         for directory in service.dirs:
-            node.privatedir(directory)
+            try:
+                node.privatedir(directory)
+            except Exception, e:
+                logger.warn("error mounting private dir '%s' for service '%s': %s", 
+                            directory, service.name, e)
+
 
         # create service files
         self.create_service_files(node, service)


### PR DESCRIPTION
Two services may require the same private directory (e.g. /var/spool), and both will invoke the privatedir() method, with the second one failing due to the directory already existing. This logs a warning instead of halting the entire session startup due to an exception.