### PR TITLE
fix DHCP server service to work under Ubuntu 18.04

### DIFF
--- a/daemon/core/services/utility.py
+++ b/daemon/core/services/utility.py
@@ -232,11 +232,11 @@ UseDNS no
 class DhcpService(UtilService):
     name = "DHCP"
     configs = ("/etc/dhcp/dhcpd.conf",)
-    dirs = ("/etc/dhcp",)
-    startup = ("dhcpd",)
+    dirs = ("/etc/dhcp","/var/lib/dhcp")
+    startup = ("touch /var/lib/dhcp/dhcpd.leases","dhcpd")
     shutdown = ("killall dhcpd",)
     validate = ("pidof dhcpd",)
-
+        
     @classmethod
     def generate_config(cls, node, filename):
         """


### PR DESCRIPTION
Fix DHCP server service to work under Ubuntu 18.04.

This worked for me using the isc-dhcp-server package version 4.3.5-3ubuntu7.