### PR TITLE
fix #290 use pythondir var as base for setting PYTHONLIBDIR

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -57,7 +57,7 @@ fi
 
 AC_ARG_ENABLE([python3],
 	       [AS_HELP_STRING([--enable-python3],
-		[enable python3 default is python2])],
+		[sets python3 flag for building packages])],
 		[enable_python3=yes], [enable_python3=no])
 AM_CONDITIONAL([PYTHON3], [test "x$enable_python3" == "xyes"])
 

--- a/configure.ac
+++ b/configure.ac
@@ -110,7 +110,6 @@ if test "x$enable_daemon" = "xyes"; then
   AC_CHECK_FUNCS([atexit dup2 gettimeofday memset socket strerror uname])
 
   AM_PATH_PYTHON(2.7)
-  AM_CONDITIONAL([PYTHON3], [test "x$PYTHON" == "xpython3"])
   AS_IF([$PYTHON -m grpc_tools.protoc -h &> /dev/null], [], [AC_MSG_ERROR([please install python grpcio-tools])])
 
   AC_CHECK_PROG(brctl_path, brctl, $as_dir, no, $SEARCHPATH)
@@ -157,6 +156,8 @@ if test "x$enable_daemon" = "xyes"; then
   CFLAGS=$CFLAGS_save
   CPPFLAGS=$CPPFLAGS_save
 fi
+AM_CONDITIONAL([PYTHON3], [test "x$PYTHON" == "xpython3"])
+
 if [ test "x$enable_daemon" = "xyes" || test "x$enable_vnodedonly" = "xyes" ] ; then
   want_linux_netns=yes
   PKG_CHECK_MODULES(libev, libev,

--- a/configure.ac
+++ b/configure.ac
@@ -54,6 +54,13 @@ if test "x$enable_python" = "xyes" ; then
 else
   want_python=no
 fi
+
+AC_ARG_ENABLE([python3],
+	       [AS_HELP_STRING([--enable-python3],
+		[enable python3 default is python2])],
+		[enable_python3=yes], [enable_python3=no])
+AM_CONDITIONAL([PYTHON3], [test "x$enable_python3" == "xyes"])
+
 AC_ARG_ENABLE([daemon],
 	       [AS_HELP_STRING([--enable-daemon[=ARG]],
 		[build and install the daemon with Python modules
@@ -156,7 +163,6 @@ if test "x$enable_daemon" = "xyes"; then
   CFLAGS=$CFLAGS_save
   CPPFLAGS=$CPPFLAGS_save
 fi
-AM_CONDITIONAL([PYTHON3], [test "x$PYTHON" == "xpython3"])
 
 if [ test "x$enable_daemon" = "xyes" || test "x$enable_vnodedonly" = "xyes" ] ; then
   want_linux_netns=yes

--- a/daemon/Makefile.am
+++ b/daemon/Makefile.am
@@ -14,11 +14,7 @@ if WANT_DOCS
 DOCS = doc
 endif
 
-if PYTHON3
-PYTHONLIBDIR=$(shell echo $(pythondir) | sed -e 's/site-packages/dist-packages/')
-else
-PYTHONLIBDIR=$(pythondir)
-endif
+PYTHONLIBDIR=$(subst site-packages,dist-packages,$(pythondir))
 
 SUBDIRS = proto $(DOCS)
 

--- a/daemon/Makefile.am
+++ b/daemon/Makefile.am
@@ -15,7 +15,7 @@ DOCS = doc
 endif
 
 if PYTHON3
-PYTHONLIBDIR=$(libdir)/python3/dist-packages
+PYTHONLIBDIR=$(shell echo $(pythondir) | sed -e 's/site-packages/dist-packages/')
 else
 PYTHONLIBDIR=$(pythondir)
 endif

--- a/docs/install.md
+++ b/docs/install.md
@@ -249,7 +249,7 @@ sudo yum -y install automake gcc python-devel libev-devel tk
 
 ```shell
 ./bootstrap.sh
-# use python2 or python3 depending on desired version
+# $VERSION should be path to python2/3
 PYTHON=$VERSION ./configure
 make
 sudo make install
@@ -268,7 +268,7 @@ sudo apt install python3-sphinx
 sudo yum install python3-sphinx
 
 ./bootstrap.sh
-# use python2 or python3 depending on desired version
+# $VERSION should be path to python2/3
 PYTHON=$VERSION ./configure
 make doc
 ```
@@ -282,8 +282,10 @@ Build package commands, DESTDIR is used to make install into and then for packag
 
 ```shell
 ./bootstrap.sh
-# use python2 or python3 depending on desired version
-PYTHON=$VERSION ./configure
+# for python2
+PYTHON=python2 ./configure
+# for python3
+PYTHON=python3 ./configure --enable-python3
 make
 mkdir /tmp/core-build
 make fpm DESTDIR=/tmp/core-build

--- a/ns3/Makefile.am
+++ b/ns3/Makefile.am
@@ -9,11 +9,7 @@
 
 if WANT_PYTHON
 
-if PYTHON3
-PYTHONLIBDIR=$(libdir)/python3/dist-packages
-else
-PYTHONLIBDIR=$(pythondir)
-endif
+PYTHONLIBDIR=$(subst site-packages,dist-packages,$(pythondir))
 
 SETUPPY	= setup.py
 SETUPPYFLAGS = -v


### PR DESCRIPTION
This causes PYTHONLIBDIR to be set to `/usr/local/lib/python3.6/dist-packages` under Ubuntu 18.04 when configured with `PYTHON=python3 ./configure`, which is in the default Python 3 search path.

Note that `/usr/lib/python3/dist-packages` is in this default path (so it works if you're configuring with `--prefix=/usr`), but the `/usr/local` path has `/usr/local/lib/python3.6/dist-packages`.