### PR TITLE
fix exception when trying to run Python script from GUI

### DIFF
--- a/daemon/core/api/tlv/corehandlers.py
+++ b/daemon/core/api/tlv/corehandlers.py
@@ -2042,6 +2042,7 @@ class CoreUdpHandler(CoreHandler):
         }
         self.master = False
         self.session = None
+        self.coreemu = server.mainserver.coreemu
         socketserver.BaseRequestHandler.__init__(self, request, client_address, server)
 
     def setup(self):


### PR DESCRIPTION
This unbreaks the "File" > "Execute XML or Python script..." feature. This allows you to write a Python script that can run a standalone emulation (as root), or optionally add the scripted session to the core-daemon, to allow the GUI to connect to that session (as non-root user).