### PR TITLE
feature/init-ebtables-for-wlan-only,

### DIFF
--- a/daemon/core/nodes/network.py
+++ b/daemon/core/nodes/network.py
@@ -202,8 +202,12 @@ class EbtablesQueue:
                 self.cmds.append(f"-F {wlan.brname}")
             else:
                 wlan.has_ebtables_chain = True
-                self.cmds.extend([f"-N {wlan.brname} -P {wlan.policy}",
-                                  f"-A FORWARD --logical-in {wlan.brname} -j {wlan.brname}"])
+                self.cmds.extend(
+                    [
+                        f"-N {wlan.brname} -P {wlan.policy}",
+                        f"-A FORWARD --logical-in {wlan.brname} -j {wlan.brname}",
+                    ]
+                )
             # rebuild the chain
             for netif1, v in wlan._linked.items():
                 for netif2, linked in v.items():


### PR DESCRIPTION
Old behavior: every Linux bridge (switch, hub, WLAN) gets an ebtables chain created for it by default.
New behavior: only WLAN nodes that actually use ebtables will get a dedicated ebtables chain.

This fixes problems when multiple CORE Python scripts run simultaneously and try to invoke ebtables at the same time (the Linux kernel can only handle one ebtables process at once.) For example, a protocol test suite that runs several tests at once.
