### PR TITLE
Feature/remove sudo from init script

### DIFF
--- a/scripts/core-daemon.in
+++ b/scripts/core-daemon.in
@@ -35,7 +35,7 @@ corestart() {
 		echo "$NAME already started"
 	else
 		echo "starting $NAME"
-		sudo $CMD 2>&1 >> "$LOG" &
+		$CMD 2>&1 >> "$LOG" &
 	fi
 
 	echo $! > "$PIDFILE"


### PR DESCRIPTION
Remove sudo from init script, since it is already running as root.