### PR TITLE
Feature/check ifc before flush

### DIFF
--- a/daemon/core/nodes/netclient.py
+++ b/daemon/core/nodes/netclient.py
@@ -126,7 +126,10 @@ class LinuxNetClient:
         :param str device: device to flush
         :return: nothing
         """
-        self.run(f"[ -e /sys/class/net/{device} ] && {IP_BIN} -6 address flush dev {device} || echo")
+        self.run(
+            f"[ -e /sys/class/net/{device} ] && {IP_BIN} -6 address flush dev {device} || true",
+            shell=True,
+        )
 
     def device_mac(self, device, mac):
         """

--- a/daemon/core/nodes/netclient.py
+++ b/daemon/core/nodes/netclient.py
@@ -126,7 +126,7 @@ class LinuxNetClient:
         :param str device: device to flush
         :return: nothing
         """
-        self.run(f"{IP_BIN} -6 address flush dev {device}")
+        self.run(f"[ -e /sys/class/net/{device} ] && {IP_BIN} -6 address flush dev {device} || echo")
 
     def device_mac(self, device, mac):
         """

--- a/daemon/core/nodes/netclient.py
+++ b/daemon/core/nodes/netclient.py
@@ -127,8 +127,7 @@ class LinuxNetClient:
         :return: nothing
         """
         self.run(
-            f"[ -e /sys/class/net/{device} ] && {IP_BIN} -6 address flush dev {device} || true",
-            shell=True,
+            f"[ -e /sys/class/net/{device} ] && {IP_BIN} -6 address flush dev {device} || true"
         )
 
     def device_mac(self, device, mac):


### PR DESCRIPTION
Don't flush IPv6 address if interface is absent.

This checks if e.g. "/sys/class/net/eth0" exists before attempting the "ip -6 addr flush" on it. This fixes shutdown exceptions if you're running a networking daemon that changes the interface (such as installing the interface into a namespace).