### PR TITLE
update dependency installer to python3

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ function install_python_depencencies() {
 }
 
 function install_python_dev_dependencies() {
-  sudo pip install pipenv grpcio-tools
+  sudo python3 -m pip install pipenv grpcio-tools
 }
 
 function install_ospf_mdr() {


### PR DESCRIPTION
@bharnden sorry, I didn't catch this until a bit after submitting the earlier PR :)

But installing grpcio-tools should also happen the python3 (rather than legacy python2) way...