### PR TITLE
updates to cases when checking existing bridges using ip -j returns a…

### DIFF
--- a/daemon/core/nodes/netclient.py
+++ b/daemon/core/nodes/netclient.py
@@ -268,7 +268,9 @@ class LinuxNetClient:
         output = self.run(f"{IP_BIN} -j link show type bridge")
         bridges = json.loads(output)
         for bridge in bridges:
-            name = bridge["ifname"]
+            name = bridge.get("ifname")
+            if not name:
+                continue
             fields = name.split(".")
             if len(fields) != 3:
                 continue


### PR DESCRIPTION
when running the following command it seems to return empty objects, possibly a bug, adding logic to avoid this causing an exception

```shell
ip -j link show type bridge
```
