### PR TITLE
systemd: fix unit file install path

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -41,7 +41,7 @@ Install Path | Description
 /usr/share/core/|Example scripts and scenarios
 /usr/share/man/man1/|Command man pages
 /etc/init.d/core-daemon|SysV startup script for daemon
-/etc/systemd/system/core-daemon.service|Systemd startup script for daemon
+/usr/lib/systemd/system/core-daemon.service|Systemd startup script for daemon
 
 # Pre-Req Installing Python
 

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -22,7 +22,7 @@ startupdir	= /etc/init.d
 startup_SCRIPTS	= core-daemon
 endif
 if WANT_SYSTEMD
-startupdir	= /etc/systemd/system
+startupdir	= /usr/lib/systemd/system
 startup_SCRIPTS	= core-daemon.service
 endif
 


### PR DESCRIPTION
The proper location for unit files is /usr/lib/systemd/system,
with /etc/systemd/system reserved for local overrides of default
package settings.

Signed-off-by: Gabriel Somlo <gsomlo@gmail.com>