### PR TITLE
services/frr.py: frrboot.sh: start 'staticd' to support static routes

### DIFF
--- a/daemon/core/services/frr.py
+++ b/daemon/core/services/frr.py
@@ -208,6 +208,9 @@ bootfrr()
     fi
 
     bootdaemon "zebra"
+    if grep -q "^ip route " $FRR_CONF; then
+        bootdaemon "staticd"
+    fi
     for r in rip ripng ospf6 ospf bgp babel; do
         if grep -q "^router \\<${r}\\>" $FRR_CONF; then
             bootdaemon "${r}d"


### PR DESCRIPTION
Unlike Quagga, FRR requires 'staticd' to be running in order
to support provisioning and use of static routes in the running
configuration (e.g., 'ip route a.b.c.d/p nexthop').

Signed-off-by: Gabriel Somlo <glsomlo@cert.org>