### PR TITLE
fix typo in DEFAULT_TERMS make gnome-terminal work

### DIFF
--- a/daemon/core/gui/coreclient.py
+++ b/daemon/core/gui/coreclient.py
@@ -46,7 +46,7 @@ DEFAULT_TERMS = {
     "konsole": "konsole -e",
     "lxterminal": "lxterminal -e",
     "xfce4-terminal": "xfce4-terminal -x",
-    "gnome-terminal": "gnome-terminal --window--",
+    "gnome-terminal": "gnome-terminal --window --",
 }
 
 


### PR DESCRIPTION
I'm importing and using DEFAULT_TERMS from a Python script.

I tried using the gnome-terminal command but it was missing this space character...