### PR TITLE
fix #387 launch gnome-terminal properly by removing extra quoting try2

### DIFF
--- a/daemon/core/gui/coreclient.py
+++ b/daemon/core/gui/coreclient.py
@@ -575,7 +575,8 @@ class CoreClient:
             output = os.popen(f"echo {terminal}").read()[:-1]
             if output in DEFAULT_TERMS:
                 terminal = DEFAULT_TERMS[output]
-            cmd = f'{terminal} {response.terminal} &'
+
+            cmd = f"{terminal} {response.terminal} &"
             logging.info("launching terminal %s", cmd)
             os.system(cmd)
         except grpc.RpcError as e:

--- a/daemon/core/gui/coreclient.py
+++ b/daemon/core/gui/coreclient.py
@@ -575,7 +575,7 @@ class CoreClient:
             output = os.popen(f"echo {terminal}").read()[:-1]
             if output in DEFAULT_TERMS:
                 terminal = DEFAULT_TERMS[output]
-            cmd = f'{terminal} "{response.terminal}" &'
+            cmd = f'{terminal} {response.terminal} &'
             logging.info("launching terminal %s", cmd)
             os.system(cmd)
         except grpc.RpcError as e:


### PR DESCRIPTION
Fix quoting to allow gnome-terminal to launch properly under coretk-gui. Tested also with xterm OK.

Redid this branch + PR using the "git commit --no-verify" option to avoid isort mangling.