### PR TITLE
fix-core-cleanup-d-kill-daemon

### DIFF
--- a/daemon/scripts/core-cleanup
+++ b/daemon/scripts/core-cleanup
@@ -19,7 +19,7 @@ PATH="/sbin:/bin:/usr/sbin:/usr/bin"
 export PATH
 
 if [ "z$1" = "z-d" ]; then
-    pypids=`pidof python python2`
+    pypids=`pidof python3 python`
     for p in $pypids; do
 	grep -q core-daemon /proc/$p/cmdline
 	if [ $? = 0 ]; then


### PR DESCRIPTION
properly kill python3-based core-daemon when using 'core-cleanup -d'
