### PR TITLE
add back grpcio-tools to requirements.txt, since configure.ac explici…

### DIFF
--- a/daemon/requirements.txt
+++ b/daemon/requirements.txt
@@ -3,6 +3,7 @@ cffi==1.14.0
 cryptography==2.8
 fabric==2.5.0
 grpcio==1.27.2
+grpcio-tools==1.21.1
 invoke==1.4.1
 lxml==4.5.0
 Mako==1.1.1


### PR DESCRIPTION
This grpcio-tools was previously in the requirements.txt, but not any longer.

It is required by configure.ac, otherwise `./configure` will fail:
```
  AM_PATH_PYTHON(3.6)
  AS_IF([$PYTHON -m grpc_tools.protoc -h &> /dev/null], [], [AC_MSG_ERROR([please install python grpcio-tools])])
```