### PR TITLE
silence emane ERROR message upon every session instantiation

### DIFF
--- a/daemon/core/emane/emanemanager.py
+++ b/daemon/core/emane/emanemanager.py
@@ -166,7 +166,7 @@ class EmaneManager(ModelManager):
         try:
             # check for emane
             args = "emane --version"
-            emane_version = utils.cmd(args)
+            emane_version = utils.cmd(args, quiet=True)
             logging.info("using EMANE: %s", emane_version)
             self.session.distributed.execute(lambda x: x.remote_cmd(args))
 

--- a/daemon/core/utils.py
+++ b/daemon/core/utils.py
@@ -197,6 +197,7 @@ def cmd(
     cwd: str = None,
     wait: bool = True,
     shell: bool = False,
+    quiet: bool = False,
 ) -> str:
     """
     Execute a command on the host and return a tuple containing the exit status and
@@ -211,7 +212,8 @@ def cmd(
     :raises CoreCommandError: when there is a non-zero exit status or the file to
         execute is not found
     """
-    logging.debug("command cwd(%s) wait(%s): %s", cwd, wait, args)
+    if not quiet:
+        logging.debug("command cwd(%s) wait(%s): %s", cwd, wait, args)
     if shell is False:
         args = shlex.split(args)
     try:
@@ -228,7 +230,8 @@ def cmd(
         else:
             return ""
     except OSError as e:
-        logging.error("cmd error: %s", e.strerror)
+        if not quiet:
+            logging.error("cmd error: %s", e.strerror)
         raise CoreCommandError(1, args, "", e.strerror)
 
 


### PR DESCRIPTION
The `cmd()` helper logs output even if you're silence logging...

Every session startup, if you have a CORE Python script, will log this ERROR:
`ERROR:root:cmd error: No such file or directory: 'emane'
`

This adds a `quiet` arg to allow omitting logged output.