### PR TITLE
Update frr.py to add staticd to daemons list

### DIFF
--- a/daemon/core/services/frr.py
+++ b/daemon/core/services/frr.py
@@ -271,6 +271,7 @@ nhrpd=yes
 eigrpd=yes
 babeld=yes
 sharpd=yes
+staticd=yes
 pbrd=yes
 bfdd=yes
 fabricd=yes


### PR DESCRIPTION
Add staticd to the list of possible daemons to be started.
http://docs.frrouting.org/en/latest/setup.html#daemons-configuration-file
https://github.com/coreemu/core/issues/397