### PR TITLE
Changed CoreNode inheritance and CoreInterface class call on physical interfaces

### DIFF
--- a/daemon/core/nodes/physical.py
+++ b/daemon/core/nodes/physical.py
@@ -12,7 +12,7 @@ from core.emulator.distributed import DistributedServer
 from core.emulator.enumerations import NodeTypes, TransportType
 from core.errors import CoreCommandError, CoreError
 from core.executables import MOUNT, TEST, UMOUNT
-from core.nodes.base import CoreNetworkBase, CoreNodeBase
+from core.nodes.base import CoreNetworkBase, CoreNode
 from core.nodes.interface import DEFAULT_MTU, CoreInterface
 from core.nodes.network import CoreNetwork
 
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from core.emulator.session import Session
 
 
-class PhysicalNode(CoreNodeBase):
+class PhysicalNode(CoreNode):
     def __init__(
         self,
         session: "Session",
@@ -216,7 +216,7 @@ class PhysicalNode(CoreNodeBase):
         raise CoreError("physical node does not support addfile")
 
 
-class Rj45Node(CoreNodeBase):
+class Rj45Node(CoreNode):
     """
     RJ45Node is a physical interface on the host linked to the emulated
     network.
@@ -245,7 +245,7 @@ class Rj45Node(CoreNodeBase):
         """
         super().__init__(session, _id, name, server)
         self.iface: CoreInterface = CoreInterface(
-            session, self, name, name, mtu, server
+            session, name, name, mtu, server, self
         )
         self.iface.transport_type = TransportType.RAW
         self.lock: threading.RLock = threading.RLock()


### PR DESCRIPTION
When you do a topology with RJ45 interface this get an error because class calls changed in latest versions and this has not been updated.
Topology:
![Screenshot from 2022-02-04 16-27-28](https://user-images.githubusercontent.com/668847/152591476-c973f99f-c1e9-4f4c-b415-b4d778796060.png)

Error:
![Screenshot from 2022-02-04 16-27-12](https://user-images.githubusercontent.com/668847/152591522-d8bafc03-fbc0-4319-ad62-4d46ec601357.png)

It's on Core release 8.0.0, with python 3.8 and FRR, if you need to know. I used this vagrant file: https://github.com/cristianbarbaro/vagrant-coreemu

So this pull request change this interface calls.

I hope this pull request is ok, if not let me know to change it.
Thanks for your work.
Mateo
