### PR TITLE
Fix for poetry command not found path error

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -20,7 +20,7 @@ fi
 
 # install tooling for invoke based installation
 python3 -m pip install --user pipx==0.16.4
-python3 -m pipx ensurepath
 export PATH=$PATH:~/.local/bin
 pipx install invoke==1.4.1
 pipx install poetry==1.1.7
+python3 -m pipx ensurepath


### PR DESCRIPTION
Because the ensurepath is run before poetry is installed you get an error that the inv command can't be found, and if you get past that and run inv install it says poetry command can't be found. If you run the ensurepath command after they are installed it works