### PR TITLE
frrboot: add fedora sbin path to default

### DIFF
--- a/daemon/core/configservices/frrservices/services.py
+++ b/daemon/core/configservices/frrservices/services.py
@@ -89,7 +89,7 @@ class FRRZebra(ConfigService):
             "frr_bin_search", default="/usr/local/bin /usr/bin /usr/lib/frr"
         ).strip('"')
         frr_sbin_search = self.node.session.options.get(
-            "frr_sbin_search", default="/usr/local/sbin /usr/sbin /usr/lib/frr"
+            "frr_sbin_search", default="/usr/local/sbin /usr/sbin /usr/lib/frr /usr/libexec/frr"
         ).strip('"')
 
         services = []

--- a/daemon/core/services/frr.py
+++ b/daemon/core/services/frr.py
@@ -142,7 +142,7 @@ class FRRZebra(CoreService):
             "frr_bin_search", '"/usr/local/bin /usr/bin /usr/lib/frr"'
         )
         frr_sbin_search = node.session.options.get(
-            "frr_sbin_search", '"/usr/local/sbin /usr/sbin /usr/lib/frr"'
+            "frr_sbin_search", '"/usr/local/sbin /usr/sbin /usr/lib/frr /usr/libexec/frr"'
         )
         cfg = """\
 #!/bin/sh

--- a/daemon/data/core.conf
+++ b/daemon/data/core.conf
@@ -5,7 +5,7 @@ grpcport = 50051
 quagga_bin_search = "/usr/local/bin /usr/bin /usr/lib/quagga"
 quagga_sbin_search = "/usr/local/sbin /usr/sbin /usr/lib/quagga"
 frr_bin_search = "/usr/local/bin /usr/bin /usr/lib/frr"
-frr_sbin_search = "/usr/local/sbin /usr/sbin /usr/lib/frr"
+frr_sbin_search = "/usr/local/sbin /usr/sbin /usr/lib/frr /usr/libexec/frr"
 
 # uncomment the following line to load custom services from the specified dir
 # this may be a comma-separated list, and directory names should be unique


### PR DESCRIPTION
Add the Fedora default location for FRR binaries (/usr/libexec/frr/*.)
to CORE's frrboot default "sbin" search path

Signed-off-by: Gabriel Somlo <gsomlo@gmail.com>