### PR TITLE
Run `apt-get update` before running `setup.sh` in `Dockerfile.ubuntu`

### DIFF
--- a/dockerfiles/Dockerfile.ubuntu
+++ b/dockerfiles/Dockerfile.ubuntu
@@ -31,13 +31,15 @@ RUN apt-get update -y && \
     apt-get autoremove -y
 
 # install core
-RUN git clone https://github.com/coreemu/core && \
+RUN apt-get update && \
+    git clone https://github.com/coreemu/core && \
     cd core && \
     git checkout ${BRANCH} && \
     ./setup.sh && \
     PATH=/root/.local/bin:$PATH inv install -v -p ${PREFIX} && \
     cd /opt && \
-    rm -rf ospf-mdr
+    rm -rf ospf-mdr && \
+    rm -rf /var/lib/apt/lists/*
 
 # install emane
 RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip && \


### PR DESCRIPTION
## Problem

`docker build` fails using `Dockerfile.ubuntu`.

## Reason

The `setup.sh` script runs `apt install` without running `apt-get update` first:

https://github.com/coreemu/core/blob/20071eed2e73a2287aa385698dd604f4933ae7ff/setup.sh#L7-L11

The script is called in the `Dockerfile.ubuntu` here:

https://github.com/coreemu/core/blob/20071eed2e73a2287aa385698dd604f4933ae7ff/dockerfiles/Dockerfile.ubuntu#L33-L40

Neither the script nor the `RUN` instruction calls `apt-get update` causing `docker build` to fail here.

## Fix

This PR adds `apt-get update` and `rm -rf /var/lib/apt/lists/*` to the `RUN` instruction.