### PR TITLE
daemon: use default_factory for mutable default fields

### DIFF
--- a/daemon/core/api/grpc/wrappers.py
+++ b/daemon/core/api/grpc/wrappers.py
@@ -601,7 +601,7 @@ class Node:
     name: str = None
     type: NodeType = NodeType.DEFAULT
     model: str = None
-    position: Position = Position(x=0, y=0)
+    position: Position = field(default_factory=Position(x=0, y=0))
     services: set[str] = field(default_factory=set)
     emane: str = None
     icon: str = None
@@ -729,9 +729,9 @@ class Session:
     dir: str = None
     user: str = None
     default_services: dict[str, set[str]] = field(default_factory=dict)
-    location: SessionLocation = SessionLocation(
+    location: SessionLocation = field(default_factory=SessionLocation(
         x=0.0, y=0.0, z=0.0, lat=47.57917, lon=-122.13232, alt=2.0, scale=150.0
-    )
+    ))
     hooks: dict[str, Hook] = field(default_factory=dict)
     metadata: dict[str, str] = field(default_factory=dict)
     file: Path = None

--- a/daemon/core/emulator/data.py
+++ b/daemon/core/emulator/data.py
@@ -231,7 +231,7 @@ class LinkData:
     network_id: int = None
     iface1: InterfaceData = None
     iface2: InterfaceData = None
-    options: LinkOptions = LinkOptions()
+    options: LinkOptions = field(default_factory=LinkOptions())
     color: str = None
     source: str = None
 


### PR DESCRIPTION
Required for Python 3.11+ as per
https://docs.python.org/3/library/dataclasses.html#mutable-default-values