### PR TITLE
Updates for CORE-GUI grpc address/port

### DIFF
--- a/daemon/core/gui/app.py
+++ b/daemon/core/gui/app.py
@@ -28,7 +28,7 @@ HEIGHT: int = 800
 
 
 class Application(ttk.Frame):
-    def __init__(self, proxy: bool, session_id: int = None) -> None:
+    def __init__(self, proxy: bool, grpc_address: str, grpc_port: int, session_id: int = None) -> None:
         super().__init__()
         # load node icons
         nutils.setup()
@@ -55,7 +55,7 @@ class Application(ttk.Frame):
         self.setup_scaling()
         self.style: ttk.Style = ttk.Style()
         self.setup_theme()
-        self.core: CoreClient = CoreClient(self, proxy)
+        self.core: CoreClient = CoreClient(self, proxy, grpc_address, grpc_port)
         self.setup_app()
         self.draw()
         self.core.setup(session_id)

--- a/daemon/core/gui/coreclient.py
+++ b/daemon/core/gui/coreclient.py
@@ -64,13 +64,19 @@ def to_dict(config: dict[str, ConfigOption]) -> dict[str, str]:
 
 
 class CoreClient:
-    def __init__(self, app: "Application", proxy: bool) -> None:
+    def __init__(self, app: "Application", proxy: bool, grpc_address: str, grpc_port: int) -> None:
         """
         Create a CoreGrpc instance
         """
         self.app: "Application" = app
         self.master: tk.Tk = app.master
-        self._client: client.CoreGrpcClient = client.CoreGrpcClient(proxy=proxy)
+
+        #Check for input validity
+        grpc_address = "localhost" if grpc_address == None else grpc_address
+        grpc_port = "50051" if grpc_port == None else grpc_port
+        
+        #Start client, session, user
+        self._client: client.CoreGrpcClient = client.CoreGrpcClient(proxy=proxy, address = f"{grpc_address}:{grpc_port}")
         self.session: Optional[Session] = None
         self.user = getpass.getuser()
 

--- a/daemon/core/scripts/gui.py
+++ b/daemon/core/scripts/gui.py
@@ -22,6 +22,16 @@ def main() -> None:
     parser.add_argument(
         "--create-dir", action="store_true", help="create gui directory and exit"
     )
+    parser.add_argument(
+        "--grpc-port",
+        dest="grpcport",
+        help="override grpc port to listen on",
+    )
+    parser.add_argument(
+        "--grpc-address",
+        dest="grpcaddress",
+        help="override grpc address to listen on",
+    )
     args = parser.parse_args()
 
     # check home directory exists and create if necessary
@@ -46,8 +56,9 @@ def main() -> None:
         utils.cmd("xhost +SI:localuser:root")
 
     # start app
+    print(args.proxy, args.grpcaddress, args.grpcport, args.session)
     images.load_all()
-    app = Application(args.proxy, args.session)
+    app = Application(args.proxy, args.grpcaddress, args.grpcport, args.session)
     app.mainloop()
 
 


### PR DESCRIPTION
It would be nice to be able to use the CORE-GUI even when running with the CORE daemon on something other than localhost:50051. I haven't had a chance to test these changes formally (running inv test-mock) but a manual test of creating a session and pinging across nodes with an emane network has worked.