### PR TITLE
daemon: support environment variables containing = for docker nodes

### DIFF
--- a/daemon/core/nodes/docker.py
+++ b/daemon/core/nodes/docker.py
@@ -269,7 +269,7 @@ class DockerNode(CoreNode):
             for line in output.split("\x00"):
                 if not line:
                     continue
-                key, value = line.split("=")
+                key, value = line.split("=", 1)
                 self.env[key] = value
             logger.debug("node(%s) pid: %s", self.name, self.pid)
             self.up = True


### PR DESCRIPTION
Parsing `/proc/{self.pid}/environ` currently fails with "too many values to unpack (expected 2)" if any of the environment variables include `=` in the value, solve by splitting only on the first `=`.