### PR TITLE
Fixing package uninstall error

### DIFF
--- a/package/after-remove-deb.sh
+++ b/package/after-remove-deb.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
-if [ -v NO_PYTHON ]; then
+if [ ! -z "${NO_PYTHON}" ]; then
   exit 0
 fi
 
 PYTHON="${PYTHON:=python3}"
-if [ -v NO_VENV ]; then
+if [ ! -z "${NO_VENV}" ]; then
   ${PYTHON} -m pip uninstall -y core
 else
   ${PYTHON} -m venv /opt/core/venv

--- a/package/after-remove-rpm.sh
+++ b/package/after-remove-rpm.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
-if [ -v NO_PYTHON ]; then
+if [ ! -z "${NO_PYTHON}" ]; then
   exit 0
 fi
 
 PYTHON="${PYTHON:=python3}"
-if [ -v NO_VENV ]; then
+if [ ! -z "${NO_VENV}" ]; then
   ${PYTHON} -m pip uninstall -y core
 else
   ${PYTHON} -m venv /opt/core/venv


### PR DESCRIPTION
The uninstall scripts use the `sh` shell but -v is a command for a `bash` shell.

I have updated the scripts to use `! -z <environment variable>` as this returns true when the environment variable has any value. This is the same approach as the after-install scripts. 