### PR TITLE
Allow negative values in config frame

### DIFF
--- a/daemon/core/gui/validation.py
+++ b/daemon/core/gui/validation.py
@@ -50,6 +50,19 @@ class PositiveIntEntry(ValidationEntry):
             return False
 
 
+class IntEntry(ValidationEntry):
+    empty: str = "0"
+
+    def is_valid(self, s: str) -> bool:
+        if not s:
+            return True
+        try:
+            int(s)
+            return True
+        except ValueError:
+            return False
+
+
 class PositiveFloatEntry(ValidationEntry):
     empty = "0.0"
 

--- a/daemon/core/gui/widgets.py
+++ b/daemon/core/gui/widgets.py
@@ -155,14 +155,14 @@ class ConfigFrame(ttk.Notebook):
                 elif option.type in INT_TYPES:
                     value.set(option.value)
                     state = tk.NORMAL if self.enabled else tk.DISABLED
-                    entry = validation.PositiveIntEntry(
+                    entry = validation.IntEntry(
                         tab.frame, textvariable=value, state=state
                     )
                     entry.grid(row=index, column=1, sticky=tk.EW)
                 elif option.type == ConfigOptionType.FLOAT:
                     value.set(option.value)
                     state = tk.NORMAL if self.enabled else tk.DISABLED
-                    entry = validation.PositiveFloatEntry(
+                    entry = validation.FloatEntry(
                         tab.frame, textvariable=value, state=state
                     )
                     entry.grid(row=index, column=1, sticky=tk.EW)


### PR DESCRIPTION
Added ability to input negative config values in gui.

This is needed specifically for some emane models which have config parameters that may expect a negative value (fixedantennagain, txpower, etc.)