### PR TITLE
grpcio-tools protobuf dependency issue

### DIFF
--- a/daemon/poetry.lock
+++ b/daemon/poetry.lock
@@ -203,7 +203,7 @@ python-versions = ">=3.8"
 
 [package.dependencies]
 grpcio = ">=1.69.0"
-protobuf = ">=5.26.1,<6.0dev"
+protobuf = ">=5.29.3,<6.0dev"
 setuptools = "*"
 
 [[package]]

--- a/daemon/poetry.lock
+++ b/daemon/poetry.lock
@@ -203,7 +203,7 @@ python-versions = ">=3.8"
 
 [package.dependencies]
 grpcio = ">=1.69.0"
-protobuf = ">=5.29.3,<6.0dev"
+protobuf = ">=5.26.1,<6.0dev"
 setuptools = "*"
 
 [[package]]

--- a/setup.sh
+++ b/setup.sh
@@ -6,6 +6,7 @@ PIPX_VERSION=1.7.1
 GRPC_VERSION=1.69.0
 INVOKE_VERSION=2.2.0
 POETRY_VERSION=1.2.1
+PROTOBUF_VERSION=5.29.3
 
 # install pre-reqs using yum/apt
 if [ -z "${NO_SYSTEM}" ]; then
@@ -15,7 +16,7 @@ if [ -z "${NO_SYSTEM}" ]; then
     sudo apt install -y ${PYTHON_DEP}-pip ${PYTHON_DEP}-venv python3-pip
     ${PYTHON} -m venv venv
     . ./venv/bin/activate
-    python -m pip install pipx==${PIPX_VERSION} grpcio==${GRPC_VERSION} grpcio-tools==${GRPC_VERSION}
+    python -m pip install pipx==${PIPX_VERSION} protobuf==${PROTOBUF_VERSION} grpcio==${GRPC_VERSION} grpcio-tools==${GRPC_VERSION}
     python -m pipx ensurepath
     python -m pipx install invoke==${INVOKE_VERSION}
     python -m pipx install poetry==${POETRY_VERSION}
@@ -25,7 +26,7 @@ if [ -z "${NO_SYSTEM}" ]; then
     sudo yum install -y ${PYTHON_DEP}-pip
     ${PYTHON} -m venv venv
     . ./venv/bin/activate
-    python -m pip install pipx==${PIPX_VERSION} grpcio==${GRPC_VERSION} grpcio-tools==${GRPC_VERSION}
+    python -m pip install pipx==${PIPX_VERSION} protobuf==${PROTOBUF_VERSION} grpcio==${GRPC_VERSION} grpcio-tools==${GRPC_VERSION}
     python -m pipx ensurepath
     python -m pipx install invoke==${INVOKE_VERSION}
     python -m pipx install poetry==${POETRY_VERSION}


### PR DESCRIPTION
As stated in issue #919, FRR zebra was hanging when Quagga was present on my machine. 

I was also unable to receive more than 64KB of data from commands through `/core/daemon/core/api/grpc/client.py`. When running a cat command through the `node_command` function on a file larger than 64KB it would just hang. 

Neither the GRPC client nor server had its max message size changed and so should have been able to send up to 4MB as that is the default.  

I was able to solve this issue by updating the protobuf version in the grpcio-tools dependencies from `>=5.26.1,<6.0dev` to `>=5.29.3,<6.0dev`.

This ensures that the same version of protobuf is used system wide.  

This issue was occurring on Ubuntu 22.04 and 24.04.
