### PR TITLE
feat: add toggle option to wait for node command to complete

### DIFF
--- a/daemon/core/gui/appconfig.py
+++ b/daemon/core/gui/appconfig.py
@@ -75,9 +75,19 @@ class NodeCommand(yaml.YAMLObject):
     yaml_tag: str = "!NodeCommand"
     yaml_loader: type[yaml.SafeLoader] = yaml.SafeLoader
 
-    def __init__(self, name: str, cmd: str) -> None:
+    def __init__(self, name: str, cmd: str, wait: bool) -> None:
         self.name: str = name
         self.cmd: str = cmd
+        self.wait: bool = wait
+
+    @classmethod
+    def from_yaml(cls, loader, node):
+        data = loader.construct_mapping(node)
+        return cls(
+            name=data.get("name", ""),
+            cmd=data.get("cmd", ""),
+            wait=data.get("wait", True),
+        )
 
 
 class PreferencesConfig(yaml.YAMLObject):

--- a/daemon/core/gui/coreclient.py
+++ b/daemon/core/gui/coreclient.py
@@ -1,6 +1,7 @@
 """
 Incorporate grpc into python tkinter GUI
 """
+
 import getpass
 import json
 import logging
@@ -82,7 +83,7 @@ class CoreClient:
         self.servers: dict[str, CoreServer] = {}
         self.custom_nodes: dict[str, NodeDraw] = {}
         self.custom_observers: dict[str, Observer] = {}
-        self.node_commands: dict[str, str] = {}
+        self.node_commands: dict[str, tuple[str, bool]] = {}
         self.read_config()
 
         # helpers
@@ -153,7 +154,7 @@ class CoreClient:
             self.custom_observers[observer.name] = observer
         # read node commands
         for node_cmd in self.app.guiconfig.node_commands:
-            self.node_commands[node_cmd.name] = node_cmd.cmd
+            self.node_commands[node_cmd.name] = (node_cmd.cmd, node_cmd.wait)
 
     def handle_events(self, event: Event) -> None:
         if not self.session or event.source == GUI_SOURCE:
@@ -760,6 +761,6 @@ class CoreClient:
         if not result:
             logger.error("error editing link: %s", link)
 
-    def run_cmd(self, node_id: int, cmd: str) -> str:
-        _, output = self.client.node_command(self.session.id, node_id, cmd)
+    def run_cmd(self, node_id: int, cmd: str, wait: bool = True) -> str:
+        _, output = self.client.node_command(self.session.id, node_id, cmd, wait=wait)
         return output

--- a/daemon/core/gui/graph/node.py
+++ b/daemon/core/gui/graph/node.py
@@ -244,9 +244,9 @@ class CanvasNode:
                 )
             if nutils.is_container(self.core_node):
                 cmds_menu = tk.Menu(self.context)
-                for name, cmd in self.app.core.node_commands.items():
+                for name, (cmd, wait) in self.app.core.node_commands.items():
                     cmd_func = functools.partial(
-                        self.app.core.run_cmd, self.core_node.id, cmd
+                        self.app.core.run_cmd, self.core_node.id, cmd, wait
                     )
                     cmds_menu.add_command(label=name, command=cmd_func)
                 themes.style_menu(cmds_menu)


### PR DESCRIPTION
This PR adds a new option for node commands where we can choose to wait, or not, for the command to complete. It fixes #924 allowing to start GUI applications like Wireshark without blocking the core's GUI.

The default behavior is to wait for completion in order to keep compatibility with previous versions.

Furthermore, I overrode the from_yaml method in NodeCommand to deal with existent configurations that do not have a "wait" value defined. In future versions, if this it no longer a problem, this method can be removed.