### PR TITLE
Fix Multiple Custom Services Directory Issue

### DIFF
--- a/daemon/core/emulator/coreemu.py
+++ b/daemon/core/emulator/coreemu.py
@@ -68,8 +68,9 @@ class CoreEmu:
         # load custom services
         custom_dir = self.config.get("custom_services_dir")
         if custom_dir is not None:
-            custom_dir = Path(custom_dir)
-            self.service_manager.load(custom_dir)
+            custom_dir = [Path(directory.strip()) for directory in custom_dir.split(',')]
+            for custom_dir in custom_dir:
+                self.service_manager.load(custom_dir)
 
     def _load_emane(self) -> None:
         """


### PR DESCRIPTION
in core.conf for custom_services_dir it says that you can use a comma separated list, but there is no logic to actually handle that case, this adds that logic.

https://github.com/coreemu/core/blob/a5cff7f99e02a2acf629e19c307926c62c818fd6/package/etc/core.conf#L10-L13