### PR TITLE
Improve docker python management

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ capability to respond faster. Feel free to join us at the link below.
 
 ## Quick Start
 
-Requires Python 3.9+. More detailed instructions and install options can be found
+Requires Python 3.10-3.12. More detailed instructions and install options can be found
 [here](https://coreemu.github.io/core/install.html).
 
 ### Package Install

--- a/dockerfiles/Dockerfile.build
+++ b/dockerfiles/Dockerfile.build
@@ -1,7 +1,11 @@
 # syntax=docker/dockerfile:1
 FROM ubuntu:20.04
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH="/root/.local/bin:${PATH}"
 WORKDIR /opt
+
+# install system dependencies
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
     automake \
@@ -13,7 +17,6 @@ RUN apt-get update -y && \
     tk \
     bash \
     gem \
-    curl \
     rpm \
     ruby \
     ca-certificates \
@@ -22,26 +25,25 @@ RUN apt-get update -y && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
+# install python and tools
+ARG PYTHON_VERSION=3.10
+ARG DOTENV_VERSION=2.8.1
+ARG GRPC_VERSION=1.69.0
+ARG INVOKE_VERSION=2.2.1
+ARG POETRY_VERSION=1.8.5
+RUN uv python install ${PYTHON_VERSION} && \
+    uv tool install invoke==${INVOKE_VERSION} && \
+    uv tool install poetry==${POETRY_VERSION} && \
+    gem install dotenv -v ${DOTENV_VERSION} && \
+    gem install fpm
+
 # clone and build core
 ARG BRANCH=master
-ARG PIPX_VERSION=1.7.1
-ARG GRPC_VERSION=1.69.0
-ARG INVOKE_VERSION=2.2.0
-ARG POETRY_VERSION=1.2.1
-ENV PATH="/root/.local/bin:${PATH}"
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    git clone https://github.com/coreemu/core.git && \
+RUN git clone https://github.com/coreemu/core.git && \
     cd core && \
-    uv self update && \
-    uv python install 3.10 && \
-    uv venv venv && \
-    uv pip install --python ./venv/bin/python pipx==${PIPX_VERSION} grpcio==${GRPC_VERSION} grpcio-tools==${GRPC_VERSION} && \
-    ./venv/bin/python -m pipx ensurepath && \
-    ./venv/bin/python -m pipx install invoke==${INVOKE_VERSION} && \
-    ./venv/bin/python -m pipx install poetry==${POETRY_VERSION} && \
-    gem install dotenv -v 2.8.1 && \
-    gem install fpm && \
     git checkout ${BRANCH} && \
+    uv venv --python ${PYTHON_VERSION} venv && \
+    uv pip install --python ./venv/bin/python grpcio==${GRPC_VERSION} grpcio-tools==${GRPC_VERSION} && \
     ./bootstrap.sh && \
     PYTHON=./venv/bin/python ./configure --prefix=/usr && \
     make -j$(nproc) && \

--- a/dockerfiles/Dockerfile.emane-python
+++ b/dockerfiles/Dockerfile.emane-python
@@ -1,5 +1,11 @@
 # syntax=docker/dockerfile:1
-FROM ubuntu:22.04
+FROM ubuntu:24.04
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH="/root/.local/bin:${PATH}"
+WORKDIR /opt
+
+# install system dependencies
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
     automake \
@@ -13,26 +19,32 @@ RUN apt-get update -y && \
     libxml2-dev \
     make \
     pkg-config \
-    python3 \
-    python3-pip \
     unzip \
     uuid-dev \
     wget && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
-WORKDIR /opt
-ARG PROTOC_VERSION=3.19.6
+
+# install python and setup venv
+ARG PYTHON_VERSION=3.12
+RUN uv python install ${PYTHON_VERSION} && \
+    uv venv --python ${PYTHON_VERSION} venv && \
+    uv pip install --python ./venv/bin/python setuptools wheel
+
+# build emane python bindings
+ARG EMANE_VERSION=1.5.3
+ARG PROTOC_VERSION=28.3
 RUN wget -q https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip && \
     mkdir protoc && \
     unzip protoc-${PROTOC_VERSION}-linux-x86_64.zip -d protoc && \
     git clone https://github.com/adjacentlink/emane.git && \
     cd emane && \
-    git checkout v1.5.2 && \
+    git checkout v${EMANE_VERSION} && \
     ./autogen.sh && \
-    PYTHON=python3 ./configure --prefix=/usr && \
+    PYTHON=/opt/venv/bin/python ./configure --prefix=/usr && \
     cd src/python && \
     PATH=/opt/protoc/bin:$PATH make && \
-    python3 setup.py bdist_wheel && \
+    /opt/venv/bin/python setup.py bdist_wheel && \
     mv dist/*.whl /opt/ && \
     cd /opt && \
     rm -rf protoc && \

--- a/dockerfiles/Dockerfile.rocky
+++ b/dockerfiles/Dockerfile.rocky
@@ -1,9 +1,9 @@
 # syntax=docker/dockerfile:1
-FROM rockylinux/rockylinux:8.10 AS ospf-rpm
+FROM rockylinux/rockylinux:9 AS ospf-rpm
 WORKDIR /opt
 RUN dnf update -y && \
     dnf install -y epel-release dnf-plugins-core && \
-    dnf config-manager --set-enabled powertools && \
+    dnf config-manager --set-enabled crb && \
     dnf update -y && \
     dnf install -y \
     texinfo \
@@ -32,57 +32,68 @@ RUN dnf update -y && \
     dnf autoremove -y && \
     dnf clean all
 
-FROM rockylinux/rockylinux:8.10
-ENV LANG en_US.UTF-8
+FROM rockylinux/rockylinux:9
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+ENV LANG=en_US.UTF-8
+ENV PATH="/root/.local/bin:${PATH}"
 WORKDIR /opt
+
+# install python
+ARG PYTHON_VERSION=3.12
+RUN uv python install ${PYTHON_VERSION}
+
 # install system dependencies
 RUN dnf update -y && \
     dnf install -y \
     xterm \
     wget \
     tcpdump \
-    python3.12 \
-    python3.12-tkinter \
+    tk \
     iproute-tc && \
     dnf autoremove -y && \
     dnf clean all
+
 # install core
 ARG CORE_VERSION=9.2.1
 ARG CORE_PACKAGE=core_${CORE_VERSION}_x86_64.rpm
 ARG PACKAGE_URL=https://github.com/coreemu/core/releases/download/release-${CORE_VERSION}/${CORE_PACKAGE}
 RUN dnf update -y && \
     wget -q ${PACKAGE_URL} && \
-    PYTHON=python3.12 dnf install -y ./${CORE_PACKAGE} && \
+    PYTHON=$(uv python find ${PYTHON_VERSION}) dnf install -y ./${CORE_PACKAGE} && \
     rm -f ${CORE_PACKAGE} && \
     dnf autoremove -y && \
     dnf clean all
+
 # install ospf mdr
 COPY --from=ospf-rpm /opt/quagga-mr-0.99*.rpm .
 RUN dnf update -y && \
-    dnf install -y \
-    ./quagga-mr-0.99*.rpm && \
+    dnf install -y ./quagga-mr-0.99*.rpm && \
     rm -f ./quagga-mr-0.99*.rpm && \
     dnf autoremove -y && \
     dnf clean all
+
 # install emane
-ARG EMANE_VERSION=1.5.2
+ARG EMANE_VERSION=1.5.3
 ARG EMANE_RELEASE=emane-${EMANE_VERSION}-release-1
-ARG EMANE_PACKAGE=${EMANE_RELEASE}.el8.x86_64.tar.gz
+ARG EMANE_PACKAGE=${EMANE_RELEASE}.el9.x86_64.tar.gz
 RUN dnf update -y && \
     wget -q https://adjacentlink.com/downloads/emane/${EMANE_PACKAGE} && \
     tar xf ${EMANE_PACKAGE} && \
-    cd ${EMANE_RELEASE}/rpms/el8/x86_64 && \
+    cd ${EMANE_RELEASE}/rpms/el9/x86_64 && \
     rm emane-spectrum-tools-*.rpm emane-model-lte*.rpm && \
     rm *devel*.rpm && \
-    dnf install -y ./emane*.rpm ./python3-emane-${EMANE_VERSION}-1.el8.noarch.rpm && \
+    dnf install -y ./emane*.rpm ./python3-emane-${EMANE_VERSION}-1.el9.noarch.rpm && \
     cd ../../../.. && \
     rm ${EMANE_PACKAGE} && \
     rm -rf ${EMANE_RELEASE} && \
     dnf autoremove -y && \
     dnf clean all
-# install emane python bindings
+
+# install emane python bindings with dependencies
 ARG VENV_PATH=/opt/core/venv
 COPY --from=emane-python /opt/emane-*.whl .
-RUN ${VENV_PATH}/bin/python -m pip install ./emane-*.whl setuptools
+RUN uv pip install --python ${VENV_PATH} 'setuptools<81' ./emane-*.whl && \
+    rm -f ./emane-*.whl
+
 # set default directory
 WORKDIR /root

--- a/dockerfiles/Dockerfile.ubuntu
+++ b/dockerfiles/Dockerfile.ubuntu
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM ubuntu:22.04 AS ospf-deb
+FROM ubuntu:24.04 AS ospf-deb
 WORKDIR /opt
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
@@ -31,36 +31,41 @@ RUN apt-get update -y && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH="/root/.local/bin:${PATH}"
 WORKDIR /opt
+
+# install python
+ARG PYTHON_VERSION=3.12
+RUN uv python install ${PYTHON_VERSION}
+
 # install system dependencies
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
     ca-certificates \
     xterm \
     psmisc \
-    python3 \
-    python3-tk \
-    python3-venv \
-    python3-pip \
+    tk \
     wget \
     iproute2 \
     iputils-ping \
-    curl \
     tcpdump && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
+
 # install core
 ARG CORE_VERSION=9.2.1
 ARG CORE_PACKAGE=core_${CORE_VERSION}_amd64.deb
 ARG PACKAGE_URL=https://github.com/coreemu/core/releases/download/release-${CORE_VERSION}/${CORE_PACKAGE}
 RUN apt-get update -y && \
     wget -q ${PACKAGE_URL} && \
-    apt-get install -y --no-install-recommends ./${CORE_PACKAGE} && \
+    PYTHON=$(uv python find ${PYTHON_VERSION}) apt-get install -y --no-install-recommends ./${CORE_PACKAGE} && \
     rm -f ${CORE_PACKAGE} && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
+
 # install ospf mdr
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
@@ -84,13 +89,15 @@ RUN git clone https://github.com/USNavalResearchLaboratory/ospf-mdr.git && \
     make install && \
     cd .. && \
     rm -rf ospf-mdr
+
 # install emane
-ARG EMANE_RELEASE=emane-1.5.1-release-1
-ARG EMANE_PACKAGE=${EMANE_RELEASE}.ubuntu-22_04.amd64.tar.gz
+ARG EMANE_VERSION=1.5.3
+ARG EMANE_RELEASE=emane-${EMANE_VERSION}-release-1
+ARG EMANE_PACKAGE=${EMANE_RELEASE}.ubuntu-24_04.amd64.tar.gz
 RUN apt-get update -y && \
     wget -q https://adjacentlink.com/downloads/emane/${EMANE_PACKAGE} && \
     tar xf ${EMANE_PACKAGE} && \
-    cd ${EMANE_RELEASE}/debs/ubuntu-22_04/amd64 && \
+    cd ${EMANE_RELEASE}/debs/ubuntu-24_04/amd64 && \
     rm emane-spectrum-tools*.deb emane-model-lte*.deb && \
     rm *dev*.deb && \
     apt-get install -y --no-install-recommends ./emane*.deb ./python3-emane_*.deb && \
@@ -99,9 +106,12 @@ RUN apt-get update -y && \
     rm -rf ${EMANE_RELEASE} && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
-# install emane python bindings
+
+# install emane python bindings with dependencies
 ARG VENV_PATH=/opt/core/venv
 COPY --from=emane-python /opt/emane-*.whl .
-RUN ${VENV_PATH}/bin/python -m pip install ./emane-*.whl
+RUN uv pip install --python ${VENV_PATH} 'setuptools<81' ./emane-*.whl && \
+    rm -f ./emane-*.whl
+
 # set default directory
 WORKDIR /root

--- a/docs/install.md
+++ b/docs/install.md
@@ -24,7 +24,7 @@ Any computer capable of running Linux should be able to run CORE. Since the phys
 containers, as a general rule you should select a machine having as much RAM and CPU resources as possible.
 
 * Linux Kernel v3.3+
-* Python 3.10+
+* Python 3.10-3.12
   * pip
   * venv
   * tcl/tk support for GUI
@@ -108,7 +108,7 @@ is ran when uninstalling and would require the same options as given, during the
 
 !!! note
 
-    PYTHON defaults to python3 for installs below, CORE requires python3.9+, pip,
+    PYTHON defaults to python3 for installs below, CORE requires Python 3.10-3.12, pip,
     tk compatibility for python gui, and venv for virtual environments
 
 Examples for install:
@@ -123,9 +123,9 @@ sudo <yum/apt> install -y ./<package>
 # disable the venv and install to python directly
 sudo NO_VENV=1 <yum/apt> install -y ./<package>
 # change python executable used to install for venv or direct installations
-sudo PYTHON=python3.9 <yum/apt> install -y ./<package>
+sudo PYTHON=python3 <yum/apt> install -y ./<package>
 # disable venv and change python executable
-sudo NO_VENV=1 PYTHON=python3.9 <yum/apt> install -y ./<package>
+sudo NO_VENV=1 PYTHON=python3 <yum/apt> install -y ./<package>
 # skip installing the python portion entirely, as you plan to carry this out yourself
 # core python wheel is located at /opt/core/core-<version>-py3-none-any.whl
 sudo NO_PYTHON=1 <yum/apt> install -y ./<package>
@@ -141,9 +141,9 @@ sudo <yum/apt> remove core
 # remove a local install
 sudo NO_VENV=1 <yum/apt> remove core
 # remove install using alternative python
-sudo PYTHON=python3.9 <yum/apt> remove core
+sudo PYTHON=python3 <yum/apt> remove core
 # remove install using alternative python and local install
-sudo NO_VENV=1 PYTHON=python3.9 <yum/apt> remove core
+sudo NO_VENV=1 PYTHON=python3 <yum/apt> remove core
 # remove install and skip python uninstall
 sudo NO_PYTHON=1 <yum/apt> remove core
 ```
@@ -248,7 +248,7 @@ When done see [Post Install](#post-install).
 For unsupported OSs you could attempt to do the following to translate
 an installation to your use case.
 
-* make sure you have python3.9+ with venv support
+* make sure you have Python 3.10-3.12 with venv support
 * make sure you have python3 invoke available to leverage `<repo>/tasks.py`
 
 ```shell


### PR DESCRIPTION
## Motivation

The existing Dockerfiles were hardcoded to use the minimum supported Python version (3.10), preventing users from easily running CORE with newer Python versions. This PR keeps the minimum supported Python version (3.10) for building CORE packages while providing the newest supported Python Version (3.12) for the Rocky Linux and Ubuntu runtime images.

## Changes

### Python Version Management
- **Adopted uv throughout**: `uv` was already used in `Dockerfile.build`. Since it provides great Python version management independent of system packages, I extended its use to all Dockerfiles.
- **Added `PYTHON_VERSION` ARG**: All Dockerfiles now accept a Python version argument (defaults: 3.10 for build, 3.12 for runtime).
- **Tested Python 3.10, 3.11, 3.12**: Python 3.10-3.12 seem fully functional. Python 3.13+ are incompatible due to `pyproj` 3.6.1 dependency.

### Base Image Updates
- **Ubuntu 22.04 -> 24.04**: Latest LTS with EMANE 1.5.3 support.
- **Rocky 8.10 -> 9**: Latest major version with EMANE 1.5.3 support.

### EMANE Updates  
- **EMANE 1.5.1/2 -> 1.5.3**: Latest stable release.
- **`protoc` 3.19.6 -> 28.3**: Newer protoc versions generate code incompatible with `protobuf` 5.29.3.
- **Pinned `setuptools<81`**: `pkg_resources` has been marked as deprecated, but is still in use by EMANE.

### Other Changes
- Removed `curl` (uv now copied from official image).
- Removed system Python packages.
- Improved consistency across Dockerfiles.
- Updated `README.md` and `install.md` Python requirement to reflect actual compatibility.
