### PR TITLE
Add Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,127 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+  attestations: write
+
+jobs:
+  build-packages:
+    name: Build Release Packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build packages
+        uses: docker/build-push-action@v6
+        with:
+          context: dockerfiles
+          file: dockerfiles/Dockerfile.build
+          build-args: BRANCH=${{ github.ref_name }}
+          push: false
+          load: true
+          tags: core-build:latest
+
+      - name: Extract packages from container
+        run: |
+          # Create output directory
+          mkdir -p packages
+          
+          # Extract packages from the build container
+          docker run --rm -v "$(pwd)/packages:/out" core-build:latest \
+            sh -c 'cp /opt/core/*.deb /opt/core/*.rpm /out/'
+
+      - name: Generate package attestations
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: packages/*
+
+      - name: Upload packages to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          for pkg in packages/*; do
+            echo "Uploading $(basename $pkg)..."
+            gh release upload ${{ github.ref_name }} "$pkg" --clobber
+          done
+
+  publish-docker-images:
+    name: Publish Docker Images
+    runs-on: ubuntu-latest
+    needs: build-packages
+    strategy:
+      matrix:
+        image: [ubuntu, rocky]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker # this way, the rocky/ubuntu images can use the emane-python image
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          # Extract version from tag (e.g., release-9.2.1 -> 9.2.1)
+          VERSION=${GITHUB_REF#refs/tags/release-}
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/core-${{ matrix.image }}
+          tags: |
+            type=raw,value=latest
+            type=match,pattern=release-(\d+),group=1
+            type=match,pattern=release-(\d+\.\d+),group=1
+            type=match,pattern=release-(\d+\.\d+\.\d+),group=1
+
+      - name: Build EMANE Python bindings
+        uses: docker/build-push-action@v6
+        with:
+          context: dockerfiles
+          file: dockerfiles/Dockerfile.emane-python
+          push: false
+          load: true
+          tags: emane-python:latest
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: dockerfiles
+          file: dockerfiles/Dockerfile.${{ matrix.image }}
+          build-args: CORE_VERSION=${{ steps.version.outputs.version }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate image attestation
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-name: ghcr.io/${{ github.repository_owner }}/core-${{ matrix.image }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
## Motivation

While working on #949, I noticed that packages (deb/rpm) and Docker images are currently created and uploaded manually. This PR introduces a release workflows to streamline the release process.

## Changes

This PR adds a GitHub workflow that automatically triggers on release publication and handles:

### Package Building & Publishing
- Builds all four package variants (core/core-distributed for deb/rpm) using `Dockerfile.build`.
- Extracts packages from the build container.
- Generates provenance attestations.
- Uploads packages to the GitHub release.

### Docker Image Building & Publishing
- Builds `core-ubuntu` and `core-rocky` images.
- Creates multi-version tags:
  - `latest` - always points to the newest release.
  - `X` - major version (e.g., `9`).
  - `X.Y` - minor version (e.g., `9.2`).
  - `X.Y.Z` - full version (e.g., `9.2.1`).
- Generates provenance attestations.
- Pushes images to GHCR.

## Testing

I tested this PR alongside the changes from #949 in [my fork](https://github.com/LeWimbes/core).
Once this PR has been merged or closed, I will delete the dummy release and images.